### PR TITLE
qtl gene focus

### DIFF
--- a/src/westminster/scripts/westminster_classify.py
+++ b/src/westminster/scripts/westminster_classify.py
@@ -14,6 +14,7 @@ import seaborn as sns
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import average_precision_score, roc_auc_score, roc_curve
 from sklearn.model_selection import KFold
+import lightgbm as lgb
 import xgboost as xgb
 
 """
@@ -120,6 +121,13 @@ def main():
         action="store_true",
         help="Use XGBoost [Default: %default]",
     )
+    parser.add_option(
+        "--lgbm",
+        dest="lgbm",
+        default=False,
+        action="store_true",
+        help="Use LightGBM [Default: %default]",
+    )
     parser.add_option("-t", dest="targets_file", default=None)
     (options, args) = parser.parse_args()
 
@@ -199,6 +207,17 @@ def main():
                 learning_rate=options.learning_rate,
                 random_state=options.random_seed,
             )
+        elif options.lgbm:
+            aurocs, fpr_folds, tpr_folds, fpr_mean, tpr_mean, preds = folds_lgbm(
+                X,
+                y,
+                folds=options.num_folds,
+                iterations=options.iterations,
+                n_estimators=options.n_estimators,
+                max_depth=options.max_depth,
+                learning_rate=options.learning_rate,
+                random_state=options.random_seed,
+            )
         else:
             aurocs, auprcs, fpr_folds, tpr_folds, fpr_mean, tpr_mean, preds = (
                 folds_randfor(
@@ -225,6 +244,14 @@ def main():
                 max_depth=options.max_depth,
                 learning_rate=options.learning_rate,
             )
+        elif options.lgbm:
+            model = full_lgbm(
+                X,
+                y,
+                n_estimators=options.n_estimators,
+                max_depth=options.max_depth,
+                learning_rate=options.learning_rate,
+            )
         else:
             model = full_randfor(
                 X, y, n_estimators=options.n_estimators, min_samples_leaf=options.msl
@@ -234,7 +261,11 @@ def main():
         # save model hyperparameters for reproducibility
         model_params = model.get_params() if hasattr(model, "get_params") else {}
         meta = {
-            "classifier": "xgboost" if options.xgboost else "random_forest",
+            "classifier": (
+                "xgboost"
+                if options.xgboost
+                else "lightgbm" if options.lgbm else "random_forest"
+            ),
             "model_params": model_params,
             "folds": options.num_folds,
             "iterations": options.iterations,
@@ -574,6 +605,128 @@ def full_xgboost(
         colsample_bytree=0.5,
         min_child_weight=2,
         random_state=random_state,
+    )
+    model.fit(X, y)
+    return model
+
+
+def folds_lgbm(
+    X: np.array,
+    y: np.array,
+    folds: int = 8,
+    iterations: int = 1,
+    n_estimators: int = 32,
+    max_depth: int = 4,
+    learning_rate: float = 0.05,
+    random_state: int = 44,
+):
+    """
+    Fit LightGBM classifiers in cross-validation.
+
+    Args:
+      X (:obj:`np.array`):
+        Feature matrix.
+      y (:obj:`np.array`):
+        Target values.
+      folds (:obj:`int`):
+        Cross folds.
+      iterations (:obj:`int`):
+        Cross fold iterations.
+      n_estimators (:obj:`int`):
+        Number of boosting rounds.
+      max_depth (:obj:`int`):
+        Maximum tree depth.
+      learning_rate (:obj:`float`):
+        Boosting learning rate.
+      random_state (:obj:`int`):
+        Random state.
+    """
+    aurocs = []
+    fpr_folds = []
+    tpr_folds = []
+    fpr_fulls = []
+    tpr_fulls = []
+    preds_return = []
+
+    fpr_mean = np.linspace(0, 1, 256)
+    tpr_mean = []
+
+    for i in tqdm(range(iterations)):
+        rs_iter = random_state + i
+        preds_full = np.zeros(y.shape)
+
+        kf = KFold(n_splits=folds, shuffle=True, random_state=rs_iter)
+
+        for train_index, test_index in kf.split(X):
+            rs_rf = None if random_state is None else rs_iter + test_index[0]
+
+            model = lgb.LGBMClassifier(
+                n_estimators=n_estimators,
+                max_depth=max_depth,
+                learning_rate=learning_rate,
+                n_jobs=-1,
+                random_state=rs_rf,
+                verbose=-1,
+            )
+            model.fit(X[train_index, :], y[train_index])
+
+            preds = model.predict_proba(X[test_index, :])[:, 1]
+            preds_full[test_index] = preds.squeeze()
+
+            fpr, tpr, _ = roc_curve(y[test_index], preds)
+            fpr_folds.append(fpr)
+            tpr_folds.append(tpr)
+
+            interp_tpr = np.interp(fpr_mean, fpr, tpr)
+            interp_tpr[0] = 0.0
+            tpr_mean.append(interp_tpr)
+
+            aurocs.append(roc_auc_score(y[test_index], preds))
+
+        fpr_full, tpr_full, _ = roc_curve(y, preds_full)
+        fpr_fulls.append(fpr_full)
+        tpr_fulls.append(tpr_full)
+        preds_return.append(preds_full)
+
+    aurocs = np.array(aurocs)
+    tpr_mean = np.array(tpr_mean).mean(axis=0)
+    preds_return = np.array(preds_return).T
+
+    return aurocs, fpr_folds, tpr_folds, fpr_mean, tpr_mean, preds_return
+
+
+def full_lgbm(
+    X: np.array,
+    y: np.array,
+    n_estimators: int = 32,
+    max_depth: int = 4,
+    learning_rate: float = 0.05,
+    random_state: int = 44,
+):
+    """
+    Fit a single LightGBM classifier on the full data.
+
+    Args:
+      X (:obj:`np.array`):
+        Feature matrix.
+      y (:obj:`np.array`):
+        Target values.
+      n_estimators (:obj:`int`):
+        Number of boosting rounds.
+      max_depth (:obj:`int`):
+        Maximum tree depth.
+      learning_rate (:obj:`float`):
+        Boosting learning rate.
+      random_state (:obj:`int`):
+        Random state.
+    """
+    model = lgb.LGBMClassifier(
+        n_estimators=n_estimators,
+        max_depth=max_depth,
+        learning_rate=learning_rate,
+        n_jobs=-1,
+        random_state=random_state,
+        verbose=-1,
     )
     model.fit(X, y)
     return model

--- a/src/westminster/scripts/westminster_classify.py
+++ b/src/westminster/scripts/westminster_classify.py
@@ -14,7 +14,6 @@ import seaborn as sns
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import average_precision_score, roc_auc_score, roc_curve
 from sklearn.model_selection import KFold
-import lightgbm as lgb
 import xgboost as xgb
 
 """
@@ -130,6 +129,9 @@ def main():
     )
     parser.add_option("-t", dest="targets_file", default=None)
     (options, args) = parser.parse_args()
+
+    if options.xgboost and options.lgbm:
+        parser.error("Options --xgboost and --lgbm are mutually exclusive.")
 
     if len(args) != 2:
         parser.error("Must provide positive and negative variant predictions.")
@@ -641,6 +643,8 @@ def folds_lgbm(
       random_state (:obj:`int`):
         Random state.
     """
+    lgb = _import_lightgbm()
+
     aurocs = []
     fpr_folds = []
     tpr_folds = []
@@ -720,6 +724,8 @@ def full_lgbm(
       random_state (:obj:`int`):
         Random state.
     """
+    lgb = _import_lightgbm()
+
     model = lgb.LGBMClassifier(
         n_estimators=n_estimators,
         max_depth=max_depth,
@@ -730,6 +736,17 @@ def full_lgbm(
     )
     model.fit(X, y)
     return model
+
+
+def _import_lightgbm():
+    """Import LightGBM only when needed for --lgbm workflows."""
+    try:
+        import lightgbm as lgb
+    except ImportError as exc:
+        raise ImportError(
+            "LightGBM is required for --lgbm. Install it with `pip install lightgbm`."
+        ) from exc
+    return lgb
 
 
 def plot_roc(fprs: np.array, tprs: np.array, out_dir: str):

--- a/src/westminster/scripts/westminster_eqtl_folds.py
+++ b/src/westminster/scripts/westminster_eqtl_folds.py
@@ -115,7 +115,7 @@ def main():
     snp_group.add_argument(
         "--gene_cov_t",
         type=float,
-        default=0.0,
+        default=0.5,
         help="Minimum gene coverage fraction to include",
     )
     snp_group.add_argument(

--- a/src/westminster/scripts/westminster_eqtl_gtex.py
+++ b/src/westminster/scripts/westminster_eqtl_gtex.py
@@ -31,7 +31,7 @@ def main():
     parser.add_argument(
         "-g",
         "--gtex_vcf_dir",
-        default="/home/drk/seqnn/data/gtex_fine/susie_pip90r",
+        default="/home/drk/seqnn/data/gtex_v11/eqtl_pip90",
         help="GTEx VCF directory",
     )
     parser.add_argument(

--- a/src/westminster/scripts/westminster_eqtl_gtexg.py
+++ b/src/westminster/scripts/westminster_eqtl_gtexg.py
@@ -7,7 +7,6 @@ import sys
 import h5py
 import numpy as np
 import pandas as pd
-import pybedtools
 from scipy.stats import spearmanr
 from sklearn.metrics import average_precision_score, roc_auc_score
 
@@ -17,7 +16,6 @@ from westminster.gtex import (
     tissue_keywords,
     trim_dot,
     variant_pos,
-    vcf_tss_dist,
 )
 
 """
@@ -41,7 +39,7 @@ def main():
     parser.add_argument(
         "-g",
         "--gtex_vcf_dir",
-        default="/home/drk/seqnn/data/gtex_fine/susie_pip90r",
+        default="/home/drk/seqnn/data/gtex_v11/eqtl_pip90",
         help="GTEx VCF directory",
     )
     parser.add_argument(
@@ -53,7 +51,7 @@ def main():
     parser.add_argument(
         "-s",
         "--snp_stat",
-        default="logSUM",
+        default="covgene/logFC",
         help="SNP statistic. [Default: %(default)s]",
     )
     parser.add_argument(
@@ -125,98 +123,46 @@ def main():
             )
             coef_r_meas = spearmanr(eqtl_meas_df.coef, eqtl_meas_df.score)[0]
 
-            # read pos+neg per-SNP aggregated scores
-            psnp_scores, _ = read_snp_scores(gtex_scores_file, keyword, args.snp_stat)
+            # score negatives at their assigned gene (INFO GENE=) on the neg
+            # HDF5, exactly as positives are scored at their eQTL gene
             gtex_nscores_file = gtex_scores_file.replace("_pos", "_neg")
-            nsnp_scores, neg_scored_snps = read_snp_scores(
-                gtex_nscores_file, keyword, args.snp_stat
+            neg_df = read_neg_vcf(f"{args.gtex_vcf_dir}/{tissue}_neg.vcf")
+            if neg_df is None:
+                print(f"Skipping {tissue}: no negatives.", file=sys.stderr)
+                continue
+            neg_df = add_scores(
+                gtex_nscores_file, keyword, neg_df, args.snp_stat, verbose=args.verbose
             )
+            neg_meas_df = neg_df[neg_df.measured]
 
-            # classification AUROC
-            Xp = list(psnp_scores.values())
-            Xn = list(nsnp_scores.values())
-            class_labels = [1] * len(Xp) + [0] * len(Xn)
-            class_scores = Xp + Xn
+            # classification AUROC/AUPRC: |gene-specific logFC| at each
+            # variant's single designated gene, positives vs negatives
+            Xp = np.abs(eqtl_df.score.values)
+            Xn = np.abs(neg_df.score.values)
+            class_labels = np.r_[np.ones(len(Xp)), np.zeros(len(Xn))]
+            class_scores = np.r_[Xp, Xn]
             class_auroc = roc_auc_score(class_labels, class_scores)
             class_auprc = average_precision_score(class_labels, class_scores)
 
-            # measured classification AUROC
-            measured_snps = set(eqtl_meas_df.variant)
-            Xp_m = [v for s, v in psnp_scores.items() if s in measured_snps]
-            Xn_m = [v for s, v in nsnp_scores.items() if s in neg_scored_snps]
-            class_labels_meas = [1] * len(Xp_m) + [0] * len(Xn_m)
-            class_scores_meas = Xp_m + Xn_m
+            # measured classification: restrict each side to in-window variants
+            Xp_m = np.abs(eqtl_meas_df.score.values)
+            Xn_m = np.abs(neg_meas_df.score.values)
+            class_labels_meas = np.r_[np.ones(len(Xp_m)), np.zeros(len(Xn_m))]
+            class_scores_meas = np.r_[Xp_m, Xn_m]
             class_auroc_meas = roc_auc_score(class_labels_meas, class_scores_meas)
             class_auprc_meas = average_precision_score(
                 class_labels_meas, class_scores_meas
             )
 
-            # compute TSS distances (dict-based: eqtl_df order != VCF order)
-            tissue_vcf_file = f"{args.gtex_vcf_dir}/{tissue}_pos.vcf"
-            pos_tss_arr = vcf_tss_dist(tissue_vcf_file, args.genes_bed_file)
-            pos_vcf_variants = [
-                line.split()[2]
-                for line in open(tissue_vcf_file)
-                if not line.startswith("##")
-            ]
-            pos_tss_map = dict(zip(pos_vcf_variants, pos_tss_arr))
-
-            neg_vcf_file = f"{args.gtex_vcf_dir}/{tissue}_neg.vcf"
-            neg_tss_arr = vcf_tss_dist(neg_vcf_file, args.genes_bed_file)
-            neg_vcf_variants = [
-                line.split()[2]
-                for line in open(neg_vcf_file)
-                if not line.startswith("##")
-            ]
-            neg_tss_map = dict(zip(neg_vcf_variants, neg_tss_arr))
-
-            # compute eQTL-gene TSS distances before grouping
-            eqtl_df["tss_dist_eqtl"] = compute_eqtl_tss_dist(eqtl_df, gene_tss)
-
-            # write combined variant table
-            pos_var_df = (
-                eqtl_df.groupby("variant", sort=False)
-                .agg(
-                    coef=("coef", "mean"),
-                    pred=("score", "mean"),
-                    tss_dist_eqtl=("tss_dist_eqtl", "min"),
-                )
-                .reset_index()
+            # write combined variant table: one designated-gene score per
+            # variant (pos = eQTL gene, neg = assigned gene)
+            pos_var_df = eqtl_df.rename(columns={"score": "pred"}).assign(label="pos")
+            neg_var_df = neg_df.rename(columns={"score": "pred"}).assign(
+                label="neg", coef=np.nan
             )
-            pos_var_df = pos_var_df[pos_var_df.variant.isin(pos_tss_map)]
-            pos_var_df["pred_agg"] = [
-                psnp_scores.get(v, 0.0) for v in pos_var_df.variant
-            ]
-            pos_var_df["tss_dist"] = [pos_tss_map[v] for v in pos_var_df.variant]
-            pos_var_df["label"] = "pos"
-
-            neg_variants = [v for v in nsnp_scores if v in neg_tss_map]
-            neg_var_df = pd.DataFrame(
-                {
-                    "variant": neg_variants,
-                    "label": "neg",
-                    "coef": np.nan,
-                    "pred": np.nan,
-                    "pred_agg": [nsnp_scores[v] for v in neg_variants],
-                    "tss_dist": [neg_tss_map[v] for v in neg_variants],
-                    "tss_dist_eqtl": np.nan,
-                }
-            )
-
-            scatter_cols = [
-                "variant",
-                "label",
-                "coef",
-                "pred",
-                "pred_agg",
-                "tss_dist",
-                "tss_dist_eqtl",
-            ]
+            scatter_cols = ["variant", "label", "coef", "pred", "measured", "tss_dist"]
             scatter_df = pd.concat(
-                [
-                    pos_var_df[scatter_cols],
-                    neg_var_df,
-                ],
+                [pos_var_df[scatter_cols], neg_var_df[scatter_cols]],
                 ignore_index=True,
             )
             scatter_df.to_csv(f"{args.out_dir}/{tissue}.tsv", index=False, sep="\t")
@@ -256,8 +202,6 @@ def main():
 
             if args.verbose:
                 print("")
-
-    pybedtools.cleanup()
 
     # form metrics table
     metrics_df = pd.DataFrame(metrics_rows)
@@ -300,29 +244,8 @@ def main():
         print("Distance top-1:     %.4f" % np.nanmean(egene_df.baseline_top1))
 
 
-def compute_eqtl_tss_dist(eqtl_df: pd.DataFrame, gene_tss: dict):
-    """Compute distance from each variant to its eQTL gene's TSS.
-
-    Args:
-        eqtl_df: DataFrame with 'variant' and 'gene' columns.
-        gene_tss: Dictionary from read_gene_tss().
-
-    Returns:
-        Series of distances, aligned with eqtl_df index.
-    """
-    dists = []
-    for _, row in eqtl_df.iterrows():
-        v_chrom, v_pos = variant_pos(row.variant)
-        gene_info = gene_tss.get(row.gene)
-        if gene_info is not None and gene_info[0] == v_chrom:
-            dists.append(abs(v_pos - gene_info[1]))
-        else:
-            dists.append(np.nan)
-    return dists
-
-
 def read_eqtl_vcf(tissue_vcf_file: str):
-    """Read eQTLs from the new gtex_eqtl VCF (INFO carries GENE, AFC)."""
+    """Read eQTLs from the new gtex_eqtl VCF (INFO carries GENE, AFC, TSSD)."""
     if not os.path.isfile(tissue_vcf_file):
         return None
     rows = []
@@ -335,9 +258,46 @@ def read_eqtl_vcf(tissue_vcf_file: str):
         info = dict(f.split("=", 1) for f in cols[7].split(";") if "=" in f)
         gene = trim_dot(info.get("GENE", ""))
         afc = float(info["AFC"])
+        tssd_raw = info.get("TSSD", ".")
+        tssd = np.nan if tssd_raw == "." else float(tssd_raw)
         if not gene:
             continue
-        rows.append({"variant": vid, "gene": gene, "coef": afc, "allele1": ref})
+        rows.append(
+            {
+                "variant": vid,
+                "gene": gene,
+                "coef": afc,
+                "allele1": ref,
+                "tss_dist": tssd,
+            }
+        )
+    return pd.DataFrame(rows) if rows else None
+
+
+def read_neg_vcf(neg_vcf_file: str):
+    """Read matched-negative variants from a gtex_eqtl {tissue}_neg.vcf.
+
+    Negatives carry an assigned gene (INFO GENE=, the nearest-cognate-feature
+    reassignment) but no AFC. Returns one row per variant with the columns
+    add_scores() needs, so each negative is scored at its assigned gene exactly
+    as a positive is scored at its eQTL gene.
+    """
+    if not os.path.isfile(neg_vcf_file):
+        return None
+    rows = []
+    for line in open(neg_vcf_file):
+        if line.startswith("#"):
+            continue
+        cols = line.rstrip("\n").split("\t")
+        vid = cols[2]
+        ref = cols[3]
+        info = dict(f.split("=", 1) for f in cols[7].split(";") if "=" in f)
+        gene = trim_dot(info.get("GENE", ""))
+        tssd_raw = info.get("TSSD", ".")
+        tssd = np.nan if tssd_raw == "." else float(tssd_raw)
+        if not gene:
+            continue
+        rows.append({"variant": vid, "gene": gene, "allele1": ref, "tss_dist": tssd})
     return pd.DataFrame(rows) if rows else None
 
 
@@ -376,6 +336,7 @@ def read_eqtl_ems(tissue: str, gtex_vcf_dir: str, pip_t: float = 0.9):
                 "gene": [trim_dot(gene_id) for gene_id in df_causal.gene],
                 "coef": df_causal.beta_posterior,
                 "allele1": df_causal.allele1,
+                "tss_dist": np.nan,
             }
         )
     return eqtl_df
@@ -523,30 +484,6 @@ def add_scores(
     eqtl_df["score"] = scores_out
     eqtl_df["measured"] = measured
     return eqtl_df
-
-
-def _aggregate_scores_across_genes(data: dict, match_tis: np.ndarray):
-    """Aggregate absolute scores across all genes for each SNP.
-
-    Args:
-        data: Data dictionary from _load_hdf5_data()
-        match_tis: Array of target indices that match the tissue
-
-    Returns:
-        snp_scores: Dictionary mapping SNP -> aggregated score
-        scored_snps: Set of SNPs with at least one gene pair
-    """
-    snp_scores = {snp: 0.0 for snp in data["snps"]}
-    scored_snps = set()
-
-    for (si, gi), row in data["pair_row"].items():
-        snp = data["snps"][si]
-        scored_snps.add(snp)
-        vals = data["stat_matrix"][row, match_tis].astype("float32")
-        score = float(np.mean(vals))
-        snp_scores[snp] += np.abs(score)
-
-    return snp_scores, scored_snps
 
 
 def _index_tss_by_chrom(gene_tss: dict):
@@ -746,23 +683,6 @@ def _topk_accuracy(scored: pd.DataFrame, score_col: str, k: int):
         if top.label.sum() > 0:
             hits += 1
     return float(hits / n) if n else float("nan")
-
-
-def read_snp_scores(gtex_scores_file, keyword, score_key="logSUM"):
-    """Return per-SNP aggregated absolute scores from gene-level HDF5.
-
-    Args:
-      gtex_scores_file (str): Path to HDF5 scores file.
-      keyword (str): Tissue keyword for matching GTEx targets.
-      score_key (str): Score key in HDF5 file.
-
-    Returns:
-      snp_scores (dict): SNP -> aggregated abs score.
-      scored_snps (set): SNPs with at least one gene pair.
-    """
-    match_tis = _match_tissue_targets(gtex_scores_file, keyword, score_key)
-    data = _load_hdf5_data(gtex_scores_file, score_key)
-    return _aggregate_scores_across_genes(data, match_tis)
 
 
 ################################################################################

--- a/src/westminster/scripts/westminster_paqtl_gtex.py
+++ b/src/westminster/scripts/westminster_paqtl_gtex.py
@@ -13,7 +13,7 @@ from westminster.gtex import (
     match_tissue_targets,
     txrev_keywords,
     gtexv11_keywords,
-    vcf_info_dist,
+    trim_dot,
 )
 
 """
@@ -21,7 +21,15 @@ westminster_paqtl_gtex.py
 
 Evaluate variant effect prediction accuracy on GTEx paQTL classification task,
 matching model targets to GTEx tissues for per-tissue AUROC/AUPRC.
+
+Each variant is scored at exactly one designated gene (INFO GENE=): positives
+at their paQTL gene, negatives at the matched-negative assigned gene. This
+avoids the gene-density bias of summing |score| across every cis gene.
 """
+
+# distance INFO tag and per-tissue-table column for paQTL
+DIST_TAG = "PD"
+DIST_COL = "pas_dist"
 
 
 ################################################################################
@@ -37,14 +45,15 @@ def main():
     )
     parser.add_argument(
         "-g",
-        "--vcf_dir",
-        default=None,
-        help="Directory containing pos_merge.vcf and neg_merge.vcf with PD= INFO tags",
+        "--gtex_vcf_dir",
+        required=True,
+        help="GTEx paQTL VCF directory with {tissue}_pos.vcf / {tissue}_neg.vcf "
+        "(INFO carries GENE and PD)",
     )
     parser.add_argument(
         "-s",
         "--snp_stat",
-        default="covgene/JSD",
+        default="covgene/PA",
         help="SNP statistic. [Default: %(default)s]",
     )
     parser.add_argument("-v", "--verbose", action="store_true")
@@ -52,13 +61,6 @@ def main():
     args = parser.parse_args()
 
     os.makedirs(args.out_dir, exist_ok=True)
-
-    # load PAS distances from merged VCFs if available
-    if args.vcf_dir is not None:
-        pos_pas_dist = vcf_info_dist(f"{args.vcf_dir}/pos_merge.vcf", "PD")
-        neg_pas_dist = vcf_info_dist(f"{args.vcf_dir}/neg_merge.vcf", "PD")
-    else:
-        pos_pas_dist = neg_pas_dist = None
 
     keyword_lookup = {
         t.replace("GTEx_txrev_", ""): kw for t, kw in txrev_keywords.items()
@@ -69,6 +71,8 @@ def main():
 
     for pos_dir in sorted(glob.glob(f"{args.paqtl_dir}/*_pos")):
         tissue_label = os.path.basename(pos_dir).removesuffix("_pos")
+        if tissue_label == "merge":
+            continue  # AlphaGenome's merge_pos staging dir, not a tissue
         if tissue_label not in keyword_lookup:
             print(f"Skipping {tissue_label}: no keyword mapping.", file=sys.stderr)
             continue
@@ -78,46 +82,69 @@ def main():
             print(tissue_label)
 
         pos_scores_file = f"{pos_dir}/scores.h5"
-        if not os.path.isfile(pos_scores_file):
-            continue
-
         neg_scores_file = pos_scores_file.replace("_pos/", "_neg/")
-        if not os.path.isfile(neg_scores_file):
+        if not os.path.isfile(pos_scores_file) or not os.path.isfile(neg_scores_file):
             continue
 
+        # read designated genes from the per-tissue VCFs
+        pos_df = read_qtl_vcf(f"{args.gtex_vcf_dir}/{tissue_label}_pos.vcf")
+        neg_df = read_qtl_vcf(f"{args.gtex_vcf_dir}/{tissue_label}_neg.vcf")
+        if pos_df is None or neg_df is None:
+            print(f"Skipping {tissue_label}: missing VCF.", file=sys.stderr)
+            continue
+
+        # score each variant at its single designated gene
         try:
-            psnp_scores, _ = read_snp_scores(pos_scores_file, keyword, args.snp_stat)
-            nsnp_scores, _ = read_snp_scores(neg_scores_file, keyword, args.snp_stat)
+            pos_df = add_scores(
+                pos_scores_file, keyword, pos_df, args.snp_stat, verbose=args.verbose
+            )
+            neg_df = add_scores(
+                neg_scores_file, keyword, neg_df, args.snp_stat, verbose=args.verbose
+            )
         except ValueError:
             print(f"Skipping {tissue_label}: no matching targets.", file=sys.stderr)
             continue
 
-        Xp = list(psnp_scores.values())
-        Xn = list(nsnp_scores.values())
-        labels = [1] * len(Xp) + [0] * len(Xn)
-        scores = Xp + Xn
-
+        # classification AUROC/AUPRC: |designated-gene score|, positives vs
+        # matched negatives
+        Xp = np.abs(pos_df.score.values)
+        Xn = np.abs(neg_df.score.values)
+        labels = np.r_[np.ones(len(Xp)), np.zeros(len(Xn))]
+        scores = np.r_[Xp, Xn]
         auroc = roc_auc_score(labels, scores)
         auprc = average_precision_score(labels, scores)
 
-        metrics_rows.append({"tissue": tissue_label, "auroc": auroc, "auprc": auprc})
-
-        # write per-variant table
-        pos_variants = list(psnp_scores.keys())
-        neg_variants = list(nsnp_scores.keys())
-        scatter_data = {
-            "variant": pos_variants + neg_variants,
-            "label": ["pos"] * len(pos_variants) + ["neg"] * len(neg_variants),
-            "pred": [psnp_scores[v] for v in pos_variants]
-            + [nsnp_scores[v] for v in neg_variants],
-        }
-        if pos_pas_dist is not None:
-            scatter_data["pas_dist"] = [
-                pos_pas_dist.get(v, np.nan) for v in pos_variants
-            ] + [neg_pas_dist.get(v, np.nan) for v in neg_variants]
-        pd.DataFrame(scatter_data).to_csv(
-            f"{args.out_dir}/{tissue_label}.tsv", index=False, sep="\t"
+        # measured classification: restrict each side to variants whose
+        # designated (variant, gene) pair was scored in-window
+        meas_frac = float(
+            np.mean(np.r_[pos_df.measured.values, neg_df.measured.values])
         )
+        Xp_m = np.abs(pos_df.score.values[pos_df.measured.values])
+        Xn_m = np.abs(neg_df.score.values[neg_df.measured.values])
+        labels_m = np.r_[np.ones(len(Xp_m)), np.zeros(len(Xn_m))]
+        scores_m = np.r_[Xp_m, Xn_m]
+        auroc_meas = roc_auc_score(labels_m, scores_m)
+        auprc_meas = average_precision_score(labels_m, scores_m)
+
+        metrics_rows.append(
+            {
+                "tissue": tissue_label,
+                "auroc": auroc,
+                "auprc": auprc,
+                "measured": meas_frac,
+                "measured_auroc": auroc_meas,
+                "measured_auprc": auprc_meas,
+            }
+        )
+
+        # write per-variant table: one designated-gene score per variant
+        pos_var = pos_df.rename(columns={"score": "pred"}).assign(label="pos")
+        neg_var = neg_df.rename(columns={"score": "pred"}).assign(label="neg")
+        scatter_cols = ["variant", "label", "pred", "measured", DIST_COL]
+        scatter_df = pd.concat(
+            [pos_var[scatter_cols], neg_var[scatter_cols]], ignore_index=True
+        )
+        scatter_df.to_csv(f"{args.out_dir}/{tissue_label}.tsv", index=False, sep="\t")
 
         if args.verbose:
             print(f"  AUROC={auroc:.4f}  AUPRC={auprc:.4f}")
@@ -128,14 +155,43 @@ def main():
         f"{args.out_dir}/metrics.tsv", sep="\t", index=False, float_format="%.4f"
     )
 
-    print("AUROC: %.4f" % np.mean(metrics_df.auroc))
-    print("AUPRC: %.4f" % np.mean(metrics_df.auprc))
+    print("AUROC:             %.4f" % np.mean(metrics_df.auroc))
+    print("AUPRC:             %.4f" % np.mean(metrics_df.auprc))
+    print("Measured fraction: %.4f" % np.mean(metrics_df.measured))
+    print("Measured AUROC:    %.4f" % np.mean(metrics_df.measured_auroc))
+    print("Measured AUPRC:    %.4f" % np.mean(metrics_df.measured_auprc))
+
+
+def read_qtl_vcf(vcf_file: str):
+    """Read variants from a per-tissue paQTL VCF (INFO carries GENE and PD).
+
+    Works for both {tissue}_pos.vcf and {tissue}_neg.vcf — both carry one
+    designated gene per variant; positive-only tags (SLOPE, NLP) are ignored.
+    Returns one row per variant with the columns add_scores() needs.
+    """
+    if not os.path.isfile(vcf_file):
+        return None
+    rows = []
+    for line in open(vcf_file):
+        if line.startswith("#"):
+            continue
+        cols = line.rstrip("\n").split("\t")
+        vid = cols[2]
+        ref = cols[3]
+        info = dict(f.split("=", 1) for f in cols[7].split(";") if "=" in f)
+        gene = trim_dot(info.get("GENE", ""))
+        if not gene:
+            continue
+        dist_raw = info.get(DIST_TAG, ".")
+        dist = np.nan if dist_raw == "." else float(dist_raw)
+        rows.append({"variant": vid, "gene": gene, "allele1": ref, DIST_COL: dist})
+    return pd.DataFrame(rows) if rows else None
 
 
 def _match_tissue_targets(
-    scores_file: str,
+    gtex_scores_file: str,
     keyword: str,
-    score_key: str = "covgene/JSD",
+    score_key: str = "covgene/PA",
     verbose: bool = False,
 ):
     """Read targets file and match tissue targets."""
@@ -145,7 +201,7 @@ def _match_tissue_targets(
     else:
         targets_name = "targets_cov.txt"
         gene_targets = False
-    targets_file = scores_file.replace("scores.h5", targets_name)
+    targets_file = gtex_scores_file.replace("scores.h5", targets_name)
     targets_df = pd.read_csv(targets_file, sep="\t", index_col=0)
 
     match_tis = match_tissue_targets(targets_df, keyword, gene_targets, verbose)
@@ -155,9 +211,9 @@ def _match_tissue_targets(
     return match_tis
 
 
-def _load_hdf5_data(scores_file: str, score_key: str):
+def _load_hdf5_data(gtex_scores_file: str, score_key: str):
     """Load basic HDF5 datasets and build index mappings."""
-    with h5py.File(scores_file, "r") as h5_file:
+    with h5py.File(gtex_scores_file, "r") as h5_file:
         snps = [s.decode("utf-8") for s in h5_file["snp"][:]]
         gene_ids_full = [g.decode("utf-8") for g in h5_file["gene_ids"][:]]
 
@@ -165,11 +221,23 @@ def _load_hdf5_data(scores_file: str, score_key: str):
         gene_idx_arr = h5_file["gene_idx"][:]
 
         if score_key not in h5_file:
-            raise KeyError(f"Score key '{score_key}' not found in {scores_file}")
+            raise KeyError(f"Score key '{score_key}' not found in {gtex_scores_file}")
         stat_matrix = h5_file[score_key][:]  # (M, T)
+
+        # Load reference alleles if available (for allele flipping)
+        ref_alleles = None
+        if "ref_allele" in h5_file:
+            ref_alleles = [a.decode("utf-8") for a in h5_file["ref_allele"][:]]
 
     # Build index mappings
     snp_to_index = {snp: i for i, snp in enumerate(snps)}
+
+    # Gene ID mapping (handle versioned IDs)
+    gene_ids_trimmed = [trim_dot(g) for g in gene_ids_full]
+    trimmed_to_index = {}
+    for idx, gtrim in enumerate(gene_ids_trimmed):
+        if gtrim not in trimmed_to_index:  # keep first occurrence
+            trimmed_to_index[gtrim] = idx
 
     # Build mapping (snp_idx, gene_idx) -> row
     pair_row = {}
@@ -179,32 +247,74 @@ def _load_hdf5_data(scores_file: str, score_key: str):
     return {
         "snps": snps,
         "gene_ids_full": gene_ids_full,
+        "ref_alleles": ref_alleles,
         "stat_matrix": stat_matrix,
         "snp_to_index": snp_to_index,
+        "trimmed_to_index": trimmed_to_index,
         "pair_row": pair_row,
     }
 
 
-def _aggregate_scores_across_genes(data: dict, match_tis: np.ndarray):
-    """Aggregate absolute scores across all genes for each SNP."""
-    snp_scores = {snp: 0.0 for snp in data["snps"]}
-    scored_snps = set()
+def add_scores(
+    gtex_scores_file: str,
+    keyword: str,
+    qtl_df: pd.DataFrame,
+    score_key: str = "covgene/PA",
+    verbose: bool = False,
+):
+    """Score each (variant, gene) pair at its designated gene.
 
-    for (si, gi), row in data["pair_row"].items():
-        snp = data["snps"][si]
-        scored_snps.add(snp)
-        vals = data["stat_matrix"][row, match_tis].astype("float32")
-        score = float(np.mean(vals))
-        snp_scores[snp] += np.abs(score)
+    1. Determine target indices matching the tissue keyword.
+    2. Build (snp_idx, gene_idx) -> row map.
+    3. For each (variant, gene) fetch its row, average the matched target
+       columns, flip sign if the VCF allele1 differs from the HDF5 reference.
 
-    return snp_scores, scored_snps
+    Returns the input DataFrame with `score` and `measured` columns added;
+    `measured` is False (score 0.0) when the pair is not present in the HDF5
+    (variant or gene out of the model's predictable window).
+    """
+    # Match tissue targets
+    match_tis = _match_tissue_targets(gtex_scores_file, keyword, score_key, verbose)
 
+    # Load HDF5 data and mappings
+    data = _load_hdf5_data(gtex_scores_file, score_key)
 
-def read_snp_scores(scores_file, keyword, score_key="covgene/JSD"):
-    """Return per-SNP aggregated absolute scores from gene-level HDF5."""
-    match_tis = _match_tissue_targets(scores_file, keyword, score_key)
-    data = _load_hdf5_data(scores_file, score_key)
-    return _aggregate_scores_across_genes(data, match_tis)
+    # Reference allele map for flipping
+    snp_ref = (
+        dict(zip(data["snps"], data["ref_alleles"])) if data["ref_alleles"] else {}
+    )
+
+    scores_out = []
+    measured = []
+    for _, qtl in qtl_df.iterrows():
+        variant = qtl.variant
+        gene_trim = qtl.gene  # already trimmed upstream
+        si = data["snp_to_index"].get(variant, None)
+        gi = data["trimmed_to_index"].get(gene_trim, None)
+        if si is not None and gi is not None:
+            row = data["pair_row"].get((si, gi), None)
+            if row is not None:
+                vals = data["stat_matrix"][row, match_tis].astype("float32")
+                sgs = float(np.mean(vals))
+                meas = True
+            else:
+                sgs = 0.0
+                meas = False
+        else:
+            sgs = 0.0
+            meas = False
+
+        # flip sign if allele1 != reference
+        if sgs != 0.0 and si is not None and data["ref_alleles"]:
+            ref_a = snp_ref[variant]
+            if ref_a != qtl.allele1:
+                sgs *= -1
+        scores_out.append(sgs)
+        measured.append(meas)
+
+    qtl_df["score"] = scores_out
+    qtl_df["measured"] = measured
+    return qtl_df
 
 
 ################################################################################

--- a/src/westminster/scripts/westminster_sqtl_gtex.py
+++ b/src/westminster/scripts/westminster_sqtl_gtex.py
@@ -13,7 +13,7 @@ from westminster.gtex import (
     match_tissue_targets,
     txrev_keywords,
     gtexv11_keywords,
-    vcf_info_dist,
+    trim_dot,
 )
 
 """
@@ -21,7 +21,15 @@ westminster_sqtl_gtex.py
 
 Evaluate variant effect prediction accuracy on GTEx sQTL classification task,
 matching model targets to GTEx tissues for per-tissue AUROC/AUPRC.
+
+Each variant is scored at exactly one designated gene (INFO GENE=): positives
+at their sQTL gene, negatives at the matched-negative assigned gene. This
+avoids the gene-density bias of summing |score| across every cis gene.
 """
+
+# distance INFO tag and per-tissue-table column for sQTL
+DIST_TAG = "SD"
+DIST_COL = "splice_dist"
 
 
 ################################################################################
@@ -37,14 +45,15 @@ def main():
     )
     parser.add_argument(
         "-g",
-        "--vcf_dir",
-        default=None,
-        help="Directory containing pos_merge.vcf and neg_merge.vcf with SD= INFO tags",
+        "--gtex_vcf_dir",
+        required=True,
+        help="GTEx sQTL VCF directory with {tissue}_pos.vcf / {tissue}_neg.vcf "
+        "(INFO carries GENE and SD)",
     )
     parser.add_argument(
         "-s",
         "--snp_stat",
-        default="covgene/logSUM",
+        default="covgene/SJ",
         help="SNP statistic. [Default: %(default)s]",
     )
     parser.add_argument("-v", "--verbose", action="store_true")
@@ -52,13 +61,6 @@ def main():
     args = parser.parse_args()
 
     os.makedirs(args.out_dir, exist_ok=True)
-
-    # load splice site distances from merged VCFs if available
-    if args.vcf_dir is not None:
-        pos_splice_dist = vcf_info_dist(f"{args.vcf_dir}/pos_merge.vcf", "SD")
-        neg_splice_dist = vcf_info_dist(f"{args.vcf_dir}/neg_merge.vcf", "SD")
-    else:
-        pos_splice_dist = neg_splice_dist = None
 
     keyword_lookup = {
         t.replace("GTEx_txrev_", ""): kw for t, kw in txrev_keywords.items()
@@ -69,6 +71,8 @@ def main():
 
     for pos_dir in sorted(glob.glob(f"{args.sqtl_dir}/*_pos")):
         tissue_label = os.path.basename(pos_dir).removesuffix("_pos")
+        if tissue_label == "merge":
+            continue  # merge_pos/ staging dir, not a tissue
         if tissue_label not in keyword_lookup:
             print(f"Skipping {tissue_label}: no keyword mapping.", file=sys.stderr)
             continue
@@ -78,46 +82,69 @@ def main():
             print(tissue_label)
 
         pos_scores_file = f"{pos_dir}/scores.h5"
-        if not os.path.isfile(pos_scores_file):
-            continue
-
         neg_scores_file = pos_scores_file.replace("_pos/", "_neg/")
-        if not os.path.isfile(neg_scores_file):
+        if not os.path.isfile(pos_scores_file) or not os.path.isfile(neg_scores_file):
             continue
 
+        # read designated genes from the per-tissue VCFs
+        pos_df = read_qtl_vcf(f"{args.gtex_vcf_dir}/{tissue_label}_pos.vcf")
+        neg_df = read_qtl_vcf(f"{args.gtex_vcf_dir}/{tissue_label}_neg.vcf")
+        if pos_df is None or neg_df is None:
+            print(f"Skipping {tissue_label}: missing VCF.", file=sys.stderr)
+            continue
+
+        # score each variant at its single designated gene
         try:
-            psnp_scores, _ = read_snp_scores(pos_scores_file, keyword, args.snp_stat)
-            nsnp_scores, _ = read_snp_scores(neg_scores_file, keyword, args.snp_stat)
+            pos_df = add_scores(
+                pos_scores_file, keyword, pos_df, args.snp_stat, verbose=args.verbose
+            )
+            neg_df = add_scores(
+                neg_scores_file, keyword, neg_df, args.snp_stat, verbose=args.verbose
+            )
         except ValueError:
             print(f"Skipping {tissue_label}: no matching targets.", file=sys.stderr)
             continue
 
-        Xp = list(psnp_scores.values())
-        Xn = list(nsnp_scores.values())
-        labels = [1] * len(Xp) + [0] * len(Xn)
-        scores = Xp + Xn
-
+        # classification AUROC/AUPRC: |designated-gene score|, positives vs
+        # matched negatives
+        Xp = np.abs(pos_df.score.values)
+        Xn = np.abs(neg_df.score.values)
+        labels = np.r_[np.ones(len(Xp)), np.zeros(len(Xn))]
+        scores = np.r_[Xp, Xn]
         auroc = roc_auc_score(labels, scores)
         auprc = average_precision_score(labels, scores)
 
-        metrics_rows.append({"tissue": tissue_label, "auroc": auroc, "auprc": auprc})
-
-        # write per-variant table
-        pos_variants = list(psnp_scores.keys())
-        neg_variants = list(nsnp_scores.keys())
-        scatter_data = {
-            "variant": pos_variants + neg_variants,
-            "label": ["pos"] * len(pos_variants) + ["neg"] * len(neg_variants),
-            "pred": [psnp_scores[v] for v in pos_variants]
-            + [nsnp_scores[v] for v in neg_variants],
-        }
-        if pos_splice_dist is not None:
-            scatter_data["splice_dist"] = [
-                pos_splice_dist.get(v, np.nan) for v in pos_variants
-            ] + [neg_splice_dist.get(v, np.nan) for v in neg_variants]
-        pd.DataFrame(scatter_data).to_csv(
-            f"{args.out_dir}/{tissue_label}.tsv", index=False, sep="\t"
+        # measured classification: restrict each side to variants whose
+        # designated (variant, gene) pair was scored in-window
+        meas_frac = float(
+            np.mean(np.r_[pos_df.measured.values, neg_df.measured.values])
         )
+        Xp_m = np.abs(pos_df.score.values[pos_df.measured.values])
+        Xn_m = np.abs(neg_df.score.values[neg_df.measured.values])
+        labels_m = np.r_[np.ones(len(Xp_m)), np.zeros(len(Xn_m))]
+        scores_m = np.r_[Xp_m, Xn_m]
+        auroc_meas = roc_auc_score(labels_m, scores_m)
+        auprc_meas = average_precision_score(labels_m, scores_m)
+
+        metrics_rows.append(
+            {
+                "tissue": tissue_label,
+                "auroc": auroc,
+                "auprc": auprc,
+                "measured": meas_frac,
+                "measured_auroc": auroc_meas,
+                "measured_auprc": auprc_meas,
+            }
+        )
+
+        # write per-variant table: one designated-gene score per variant
+        pos_var = pos_df.rename(columns={"score": "pred"}).assign(label="pos")
+        neg_var = neg_df.rename(columns={"score": "pred"}).assign(label="neg")
+        scatter_cols = ["variant", "label", "pred", "measured", DIST_COL]
+        scatter_df = pd.concat(
+            [pos_var[scatter_cols], neg_var[scatter_cols]], ignore_index=True
+        )
+        scatter_df.to_csv(f"{args.out_dir}/{tissue_label}.tsv", index=False, sep="\t")
 
         if args.verbose:
             print(f"  AUROC={auroc:.4f}  AUPRC={auprc:.4f}")
@@ -128,14 +155,43 @@ def main():
         f"{args.out_dir}/metrics.tsv", sep="\t", index=False, float_format="%.4f"
     )
 
-    print("AUROC: %.4f" % np.mean(metrics_df.auroc))
-    print("AUPRC: %.4f" % np.mean(metrics_df.auprc))
+    print("AUROC:             %.4f" % np.mean(metrics_df.auroc))
+    print("AUPRC:             %.4f" % np.mean(metrics_df.auprc))
+    print("Measured fraction: %.4f" % np.mean(metrics_df.measured))
+    print("Measured AUROC:    %.4f" % np.mean(metrics_df.measured_auroc))
+    print("Measured AUPRC:    %.4f" % np.mean(metrics_df.measured_auprc))
+
+
+def read_qtl_vcf(vcf_file: str):
+    """Read variants from a per-tissue sQTL VCF (INFO carries GENE and SD).
+
+    Works for both {tissue}_pos.vcf and {tissue}_neg.vcf — both carry one
+    designated gene per variant; positive-only tags (SLOPE, NLP) are ignored.
+    Returns one row per variant with the columns add_scores() needs.
+    """
+    if not os.path.isfile(vcf_file):
+        return None
+    rows = []
+    for line in open(vcf_file):
+        if line.startswith("#"):
+            continue
+        cols = line.rstrip("\n").split("\t")
+        vid = cols[2]
+        ref = cols[3]
+        info = dict(f.split("=", 1) for f in cols[7].split(";") if "=" in f)
+        gene = trim_dot(info.get("GENE", ""))
+        if not gene:
+            continue
+        dist_raw = info.get(DIST_TAG, ".")
+        dist = np.nan if dist_raw == "." else float(dist_raw)
+        rows.append({"variant": vid, "gene": gene, "allele1": ref, DIST_COL: dist})
+    return pd.DataFrame(rows) if rows else None
 
 
 def _match_tissue_targets(
-    scores_file: str,
+    gtex_scores_file: str,
     keyword: str,
-    score_key: str = "covgene/logSUM",
+    score_key: str = "covgene/SJ",
     verbose: bool = False,
 ):
     """Read targets file and match tissue targets."""
@@ -145,7 +201,7 @@ def _match_tissue_targets(
     else:
         targets_name = "targets_cov.txt"
         gene_targets = False
-    targets_file = scores_file.replace("scores.h5", targets_name)
+    targets_file = gtex_scores_file.replace("scores.h5", targets_name)
     targets_df = pd.read_csv(targets_file, sep="\t", index_col=0)
 
     match_tis = match_tissue_targets(targets_df, keyword, gene_targets, verbose)
@@ -155,9 +211,9 @@ def _match_tissue_targets(
     return match_tis
 
 
-def _load_hdf5_data(scores_file: str, score_key: str):
+def _load_hdf5_data(gtex_scores_file: str, score_key: str):
     """Load basic HDF5 datasets and build index mappings."""
-    with h5py.File(scores_file, "r") as h5_file:
+    with h5py.File(gtex_scores_file, "r") as h5_file:
         snps = [s.decode("utf-8") for s in h5_file["snp"][:]]
         gene_ids_full = [g.decode("utf-8") for g in h5_file["gene_ids"][:]]
 
@@ -165,11 +221,23 @@ def _load_hdf5_data(scores_file: str, score_key: str):
         gene_idx_arr = h5_file["gene_idx"][:]
 
         if score_key not in h5_file:
-            raise KeyError(f"Score key '{score_key}' not found in {scores_file}")
+            raise KeyError(f"Score key '{score_key}' not found in {gtex_scores_file}")
         stat_matrix = h5_file[score_key][:]  # (M, T)
+
+        # Load reference alleles if available (for allele flipping)
+        ref_alleles = None
+        if "ref_allele" in h5_file:
+            ref_alleles = [a.decode("utf-8") for a in h5_file["ref_allele"][:]]
 
     # Build index mappings
     snp_to_index = {snp: i for i, snp in enumerate(snps)}
+
+    # Gene ID mapping (handle versioned IDs)
+    gene_ids_trimmed = [trim_dot(g) for g in gene_ids_full]
+    trimmed_to_index = {}
+    for idx, gtrim in enumerate(gene_ids_trimmed):
+        if gtrim not in trimmed_to_index:  # keep first occurrence
+            trimmed_to_index[gtrim] = idx
 
     # Build mapping (snp_idx, gene_idx) -> row
     pair_row = {}
@@ -179,32 +247,74 @@ def _load_hdf5_data(scores_file: str, score_key: str):
     return {
         "snps": snps,
         "gene_ids_full": gene_ids_full,
+        "ref_alleles": ref_alleles,
         "stat_matrix": stat_matrix,
         "snp_to_index": snp_to_index,
+        "trimmed_to_index": trimmed_to_index,
         "pair_row": pair_row,
     }
 
 
-def _aggregate_scores_across_genes(data: dict, match_tis: np.ndarray):
-    """Aggregate absolute scores across all genes for each SNP."""
-    snp_scores = {snp: 0.0 for snp in data["snps"]}
-    scored_snps = set()
+def add_scores(
+    gtex_scores_file: str,
+    keyword: str,
+    qtl_df: pd.DataFrame,
+    score_key: str = "covgene/SJ",
+    verbose: bool = False,
+):
+    """Score each (variant, gene) pair at its designated gene.
 
-    for (si, gi), row in data["pair_row"].items():
-        snp = data["snps"][si]
-        scored_snps.add(snp)
-        vals = data["stat_matrix"][row, match_tis].astype("float32")
-        score = float(np.mean(vals))
-        snp_scores[snp] += np.abs(score)
+    1. Determine target indices matching the tissue keyword.
+    2. Build (snp_idx, gene_idx) -> row map.
+    3. For each (variant, gene) fetch its row, average the matched target
+       columns, flip sign if the VCF allele1 differs from the HDF5 reference.
 
-    return snp_scores, scored_snps
+    Returns the input DataFrame with `score` and `measured` columns added;
+    `measured` is False (score 0.0) when the pair is not present in the HDF5
+    (variant or gene out of the model's predictable window).
+    """
+    # Match tissue targets
+    match_tis = _match_tissue_targets(gtex_scores_file, keyword, score_key, verbose)
 
+    # Load HDF5 data and mappings
+    data = _load_hdf5_data(gtex_scores_file, score_key)
 
-def read_snp_scores(scores_file, keyword, score_key="covgene/logSUM"):
-    """Return per-SNP aggregated absolute scores from gene-level HDF5."""
-    match_tis = _match_tissue_targets(scores_file, keyword, score_key)
-    data = _load_hdf5_data(scores_file, score_key)
-    return _aggregate_scores_across_genes(data, match_tis)
+    # Reference allele map for flipping
+    snp_ref = (
+        dict(zip(data["snps"], data["ref_alleles"])) if data["ref_alleles"] else {}
+    )
+
+    scores_out = []
+    measured = []
+    for _, qtl in qtl_df.iterrows():
+        variant = qtl.variant
+        gene_trim = qtl.gene  # already trimmed upstream
+        si = data["snp_to_index"].get(variant, None)
+        gi = data["trimmed_to_index"].get(gene_trim, None)
+        if si is not None and gi is not None:
+            row = data["pair_row"].get((si, gi), None)
+            if row is not None:
+                vals = data["stat_matrix"][row, match_tis].astype("float32")
+                sgs = float(np.mean(vals))
+                meas = True
+            else:
+                sgs = 0.0
+                meas = False
+        else:
+            sgs = 0.0
+            meas = False
+
+        # flip sign if allele1 != reference
+        if sgs != 0.0 and si is not None and data["ref_alleles"]:
+            ref_a = snp_ref[variant]
+            if ref_a != qtl.allele1:
+                sgs *= -1
+        scores_out.append(sgs)
+        measured.append(meas)
+
+    qtl_df["score"] = scores_out
+    qtl_df["measured"] = measured
+    return qtl_df
 
 
 ################################################################################


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the Westminster eQTL and classification scripts, with a major focus on adding LightGBM support for classification, improving the handling and scoring of positive and negative variants, and simplifying/clarifying code for the GTEx eQTL evaluation pipeline.

**Key changes include:**
- Adding LightGBM (`lgbm`) as a supported classifier option in `westminster_classify.py`, with corresponding cross-validation and full-data training routines.
- Refactoring the GTEx eQTL evaluation scripts to score each variant at a single designated gene, improving the biological interpretability and avoiding gene-density bias.
- Simplifying and updating the code for handling negative variants, TSS distances, and variant scoring.
- Adjusting some script defaults and cleaning up unused code.

---

### Classification Improvements

* Added LightGBM (`lgbm`) as a classifier option in `westminster_classify.py`, including new command-line arguments, cross-validation (`folds_lgbm`) and full-data (`full_lgbm`) training routines, and correct classifier metadata reporting. [[1]](diffhunk://#diff-7e24c7ad51e1b41b168e5c657290ae74b7a5299688dc4bf537fad825bae1d28bR17) [[2]](diffhunk://#diff-7e24c7ad51e1b41b168e5c657290ae74b7a5299688dc4bf537fad825bae1d28bR124-R130) [[3]](diffhunk://#diff-7e24c7ad51e1b41b168e5c657290ae74b7a5299688dc4bf537fad825bae1d28bR210-R220) [[4]](diffhunk://#diff-7e24c7ad51e1b41b168e5c657290ae74b7a5299688dc4bf537fad825bae1d28bR247-R254) [[5]](diffhunk://#diff-7e24c7ad51e1b41b168e5c657290ae74b7a5299688dc4bf537fad825bae1d28bL237-R268) [[6]](diffhunk://#diff-7e24c7ad51e1b41b168e5c657290ae74b7a5299688dc4bf537fad825bae1d28bR613-R734)

### eQTL Evaluation Pipeline Refactor

* Refactored `westminster_eqtl_gtexg.py` so that each variant is scored at exactly one designated gene (positives at their eQTL gene, negatives at their assigned gene), and updated the code for reading and handling negative variants via a new `read_neg_vcf` function. [[1]](diffhunk://#diff-cc70b6dadf5d1118a6279c21fd4a6ce1d11db719c7f1a902f7b5eab4486af97bL128-R165) [[2]](diffhunk://#diff-cc70b6dadf5d1118a6279c21fd4a6ce1d11db719c7f1a902f7b5eab4486af97bR261-R300)
* Updated the variant output tables to include per-variant, per-gene scores and TSS distances, and simplified the aggregation logic. [[1]](diffhunk://#diff-cc70b6dadf5d1118a6279c21fd4a6ce1d11db719c7f1a902f7b5eab4486af97bL128-R165) [[2]](diffhunk://#diff-cc70b6dadf5d1118a6279c21fd4a6ce1d11db719c7f1a902f7b5eab4486af97bR261-R300) [[3]](diffhunk://#diff-cc70b6dadf5d1118a6279c21fd4a6ce1d11db719c7f1a902f7b5eab4486af97bR339)
* Removed legacy code for aggregating scores across all genes per SNP and for computing TSS distances using BED files, as this is now handled via INFO tags in the VCFs. [[1]](diffhunk://#diff-cc70b6dadf5d1118a6279c21fd4a6ce1d11db719c7f1a902f7b5eab4486af97bL303-R248) [[2]](diffhunk://#diff-cc70b6dadf5d1118a6279c21fd4a6ce1d11db719c7f1a902f7b5eab4486af97bL528-L551) [[3]](diffhunk://#diff-cc70b6dadf5d1118a6279c21fd4a6ce1d11db719c7f1a902f7b5eab4486af97bL751-L767)

### Defaults and Minor Fixes

* Changed the default `gene_cov_t` parameter in `westminster_eqtl_folds.py` from 0.0 to 0.5 for improved filtering.
* Updated default GTEx VCF directory paths in both `westminster_eqtl_gtex.py` and `westminster_eqtl_gtexg.py` for consistency with new data locations. [[1]](diffhunk://#diff-f8628df312ce87147d34837e52a5b5076c14ee5b1e8e7f96eb905f2bc9b0a86cL34-R34) [[2]](diffhunk://#diff-cc70b6dadf5d1118a6279c21fd4a6ce1d11db719c7f1a902f7b5eab4486af97bL44-R42)
* Changed the default SNP statistic in `westminster_eqtl_gtexg.py` to `covgene/logFC` for improved scoring.

### Code Cleanup

* Removed unused imports and deprecated code (e.g., `pybedtools`, legacy score aggregation functions). [[1]](diffhunk://#diff-cc70b6dadf5d1118a6279c21fd4a6ce1d11db719c7f1a902f7b5eab4486af97bL10) [[2]](diffhunk://#diff-cc70b6dadf5d1118a6279c21fd4a6ce1d11db719c7f1a902f7b5eab4486af97bL20) [[3]](diffhunk://#diff-cc70b6dadf5d1118a6279c21fd4a6ce1d11db719c7f1a902f7b5eab4486af97bL260-L261) [[4]](diffhunk://#diff-cc70b6dadf5d1118a6279c21fd4a6ce1d11db719c7f1a902f7b5eab4486af97bL528-L551) [[5]](diffhunk://#diff-cc70b6dadf5d1118a6279c21fd4a6ce1d11db719c7f1a902f7b5eab4486af97bL751-L767)
* Added clarifying comments and improved docstrings throughout the affected scripts.

These changes collectively improve classification flexibility, scoring accuracy, and code maintainability for the Westminster eQTL analysis pipeline.