### PR TITLE
Classify w/ gene scores

### DIFF
--- a/src/westminster/scripts/westminster_classify.py
+++ b/src/westminster/scripts/westminster_classify.py
@@ -114,6 +114,15 @@ def main():
         help="HDF5 key stat to consider. [Default: %default]",
     )
     parser.add_option(
+        "--gene_agg",
+        dest="gene_agg",
+        default="none",
+        type="choice",
+        choices=["none", "max", "sum"],
+        help="Aggregate pair-indexed (covgene/) scores across genes to one row "
+        "per SNP, weighting genes evenly. [Default: %default]",
+    )
+    parser.add_option(
         "-x",
         dest="xgboost",
         default=False,
@@ -158,14 +167,15 @@ def main():
         targets_df = pd.read_csv(options.targets_file, sep="\t", index_col=0)
         target_slice = targets_df.index
 
-    # read positive/negative variants
-    Xp = read_scores(sadp_file, options.score_keys, target_slice)
-    Xn = read_scores(sadn_file, options.score_keys, target_slice)
+    # read positive/negative variants (abs + gene aggregation applied within)
+    Xp = read_scores(
+        sadp_file, options.score_keys, target_slice, options.abs_value, options.gene_agg
+    )
+    Xn = read_scores(
+        sadn_file, options.score_keys, target_slice, options.abs_value, options.gene_agg
+    )
 
     # transformations
-    if options.abs_value:
-        Xp = np.abs(Xp)
-        Xn = np.abs(Xn)
     if options.model_pkl:
         Xp = model.transform(Xp)
         Xn = model.transform(Xn)
@@ -272,6 +282,7 @@ def main():
             "folds": options.num_folds,
             "iterations": options.iterations,
             "score_keys": options.score_keys,
+            "gene_agg": options.gene_agg,
             "abs_value": options.abs_value,
             "indel": options.indel,
             "indel_scale": options.indel_scale,
@@ -807,9 +818,23 @@ def read_indel(h5_file, indel_abs=True, indel_bool=False):
     return indels
 
 
-def read_scores(stats_h5_file: str, score_keys: List[str], target_slice: np.array):
+def read_scores(
+    stats_h5_file: str,
+    score_keys: List[str],
+    target_slice: np.array,
+    abs_value: bool = False,
+    gene_agg: str = "none",
+):
     """
     Read variant scores from HDF5 file.
+
+    For pair-indexed stats (covgene/), the file carries a `snp_idx` dataset
+    mapping each row to its base SNP, so one SNP spans several gene rows. When
+    `gene_agg` is "max" or "sum", those rows are collapsed to a single feature
+    vector per SNP (genes weighted evenly), yielding one row per SNP ordered by
+    ascending SNP index. SNP-indexed cov/ files have no `snp_idx`, so the flag
+    is a no-op for them. `abs_value` is applied before aggregation so that
+    "max" selects the strongest-magnitude gene.
 
     Args:
       stats_h5_file (:obj:`str`):
@@ -818,6 +843,10 @@ def read_scores(stats_h5_file: str, score_keys: List[str], target_slice: np.arra
         Stat HDF5 keys.
       target_slice (:obj:`np.array`):
         Target axis slice.
+      abs_value (:obj:`bool`):
+        Take absolute value of features.
+      gene_agg (:obj:`str`):
+        Per-SNP gene aggregation: "none", "max", or "sum".
     """
     scores = []
     with h5py.File(stats_h5_file, "r") as stats_h5:
@@ -828,9 +857,35 @@ def read_scores(stats_h5_file: str, score_keys: List[str], target_slice: np.arra
             score = np.nan_to_num(score).astype("float32")
             scores.append(score)
 
-    # S x V x T to V x (ST)
-    scores = np.concatenate(scores, axis=-1)
+        # S x V x T to V x (ST)
+        scores = np.concatenate(scores, axis=-1)
+
+        if abs_value:
+            scores = np.abs(scores)
+
+        # collapse pair-indexed (covgene/) rows to one per SNP
+        if gene_agg != "none" and "snp_idx" in stats_h5:
+            snp_idx = stats_h5["snp_idx"][:]
+            scores = aggregate_genes(scores, snp_idx, gene_agg)
+
     return scores
+
+
+def aggregate_genes(scores: np.array, snp_idx: np.array, gene_agg: str):
+    """Collapse pair-indexed rows to one feature vector per SNP.
+
+    Args:
+      scores (:obj:`np.array`):
+        Pair-indexed feature matrix (num_pairs, T).
+      snp_idx (:obj:`np.array`):
+        Base SNP index for each row.
+      gene_agg (:obj:`str`):
+        "max" or "sum" reduction across each SNP's gene rows.
+    """
+    reduce_fn = np.maximum.reduce if gene_agg == "max" else np.sum
+    snp_order = sorted(set(int(s) for s in snp_idx))
+    agg = [reduce_fn(scores[snp_idx == si], axis=0) for si in snp_order]
+    return np.array(agg, dtype="float32")
 
 
 ################################################################################

--- a/src/westminster/scripts/westminster_classify.py
+++ b/src/westminster/scripts/westminster_classify.py
@@ -119,8 +119,8 @@ def main():
         default="none",
         type="choice",
         choices=["none", "max", "sum"],
-        help="Aggregate pair-indexed (covgene/) scores across genes to one row "
-        "per SNP, weighting genes evenly. [Default: %default]",
+        help="Aggregate pair-indexed (covgene/, gene/) scores across genes to one row "
+        "per SNP, weighting genes evenly. [Default: %default]", 
     )
     parser.add_option(
         "-x",

--- a/src/westminster/scripts/westminster_classify.py
+++ b/src/westminster/scripts/westminster_classify.py
@@ -890,7 +890,7 @@ def read_scores(
             score = stats_h5[sk][:]
             if target_slice is not None:
                 score = score[..., target_slice]
-            np.nan_to_num(score, copy=False)
+            score = np.nan_to_num(score, copy=False)
             if abs_value:
                 np.abs(score, out=score)
 

--- a/src/westminster/scripts/westminster_classify.py
+++ b/src/westminster/scripts/westminster_classify.py
@@ -116,11 +116,12 @@ def main():
     parser.add_option(
         "--gene_agg",
         dest="gene_agg",
-        default="none",
+        default="max",
         type="choice",
-        choices=["none", "max", "sum"],
-        help="Aggregate pair-indexed (covgene/) scores across genes to one row "
-        "per SNP, weighting genes evenly. [Default: %default]",
+        choices=["max", "sum"],
+        help="Reduction for collapsing pair-indexed (covgene/, gene/) scores "
+        "across genes to one row per SNP; ignored for SNP-indexed cov/ stats. "
+        "[Default: %default]",
     )
     parser.add_option(
         "-x",
@@ -824,16 +825,16 @@ def read_scores(
     score_keys: List[str],
     target_slice: np.array,
     abs_value: bool = False,
-    gene_agg: str = "none",
+    gene_agg: str = "max",
 ):
     """
     Read variant scores from HDF5 file.
 
     For pair-indexed stats (covgene/, gene/), the file carries a `snp_idx`
     dataset mapping each row to its base SNP, so one SNP spans several gene rows.
-    When `gene_agg` is "max" or "sum", those rows are collapsed to a single
-    feature vector per SNP (genes weighted evenly). SNP-indexed cov/ stats have
-    one row per SNP and no gene structure, so the flag is a no-op for them.
+    Those rows are always collapsed to a single feature vector per SNP (genes
+    weighted evenly) via the `gene_agg` reduction. SNP-indexed cov/ stats have
+    one row per SNP and no gene structure, so `gene_agg` is a no-op for them.
 
     Combining stats from different index families (e.g. cov/ with covgene/) is
     supported: each pair-indexed key is aggregated to per-SNP and reindexed onto
@@ -856,7 +857,7 @@ def read_scores(
       abs_value (:obj:`bool`):
         Take absolute value of features.
       gene_agg (:obj:`str`):
-        Per-SNP gene aggregation: "none", "max", or "sum".
+        Per-SNP gene aggregation: "max" or "sum".
     """
     with h5py.File(stats_h5_file, "r") as stats_h5:
         snp_idx = stats_h5["snp_idx"][:] if "snp_idx" in stats_h5 else None
@@ -867,7 +868,10 @@ def read_scores(
             and (sk.startswith("covgene/") or sk.startswith("gene/"))
             for sk in score_keys
         ]
-        aggregate = gene_agg != "none" and any(pair_indexed)
+
+        # pair-indexed rows (one per SNP x gene) are always collapsed to one row
+        # per SNP; the reduction is a no-op for SNP-indexed cov/ stats
+        aggregate = any(pair_indexed)
         mixed = aggregate and not all(pair_indexed)
 
         # contiguous SNP groups for collapsing pair rows, plus the full SNP

--- a/src/westminster/scripts/westminster_classify.py
+++ b/src/westminster/scripts/westminster_classify.py
@@ -197,6 +197,7 @@ def main():
     # combine
     X = np.concatenate([Xp, Xn], axis=0)
     y = np.array([True] * Xp.shape[0] + [False] * Xn.shape[0], dtype="bool")
+    del Xp, Xn
 
     # train classifier
     if X.shape[1] == 1:
@@ -828,13 +829,22 @@ def read_scores(
     """
     Read variant scores from HDF5 file.
 
-    For pair-indexed stats (covgene/), the file carries a `snp_idx` dataset
-    mapping each row to its base SNP, so one SNP spans several gene rows. When
-    `gene_agg` is "max" or "sum", those rows are collapsed to a single feature
-    vector per SNP (genes weighted evenly), yielding one row per SNP ordered by
-    ascending SNP index. SNP-indexed cov/ files have no `snp_idx`, so the flag
-    is a no-op for them. `abs_value` is applied before aggregation so that
-    "max" selects the strongest-magnitude gene.
+    For pair-indexed stats (covgene/, gene/), the file carries a `snp_idx`
+    dataset mapping each row to its base SNP, so one SNP spans several gene rows.
+    When `gene_agg` is "max" or "sum", those rows are collapsed to a single
+    feature vector per SNP (genes weighted evenly). SNP-indexed cov/ stats have
+    one row per SNP and no gene structure, so the flag is a no-op for them.
+
+    Combining stats from different index families (e.g. cov/ with covgene/) is
+    supported: each pair-indexed key is aggregated to per-SNP and reindexed onto
+    the full SNP set (the cov/ rows), filling SNPs with no gene rows with zeros,
+    so all keys share one row per SNP before concatenation. When every key is
+    pair-indexed, the compact per-SNP-with-genes ordering is kept instead.
+
+    `abs_value` is applied before aggregation so that "max" selects the
+    strongest-magnitude gene. Each pair-indexed key is reduced in its native
+    HDF5 dtype (f16) and only the collapsed result is upcast to float32, so the
+    full pair matrix is never materialized at float32.
 
     Args:
       stats_h5_file (:obj:`str`):
@@ -848,44 +858,75 @@ def read_scores(
       gene_agg (:obj:`str`):
         Per-SNP gene aggregation: "none", "max", or "sum".
     """
-    scores = []
     with h5py.File(stats_h5_file, "r") as stats_h5:
-        for sk in score_keys:
+        snp_idx = stats_h5["snp_idx"][:] if "snp_idx" in stats_h5 else None
+
+        # covgene/ and gene/ stats are pair-indexed (one row per SNP x gene)
+        pair_indexed = [
+            snp_idx is not None
+            and (sk.startswith("covgene/") or sk.startswith("gene/"))
+            for sk in score_keys
+        ]
+        aggregate = gene_agg != "none" and any(pair_indexed)
+        mixed = aggregate and not all(pair_indexed)
+
+        # contiguous SNP groups for collapsing pair rows, plus the full SNP
+        # count needed to align pair-indexed keys with SNP-indexed ones
+        if aggregate:
+            order, group_starts, group_snps = gene_groups(snp_idx)
+            n_snps = (
+                next(
+                    stats_h5[sk].shape[0]
+                    for sk, p in zip(score_keys, pair_indexed)
+                    if not p
+                )
+                if mixed
+                else None
+            )
+        reduceat = np.maximum.reduceat if gene_agg == "max" else np.add.reduceat
+
+        key_scores = []
+        for sk, is_pair in zip(score_keys, pair_indexed):
             score = stats_h5[sk][:]
             if target_slice is not None:
                 score = score[..., target_slice]
-            score = np.nan_to_num(score).astype("float32")
-            scores.append(score)
+            np.nan_to_num(score, copy=False)
+            if abs_value:
+                np.abs(score, out=score)
 
-        # S x V x T to V x (ST)
-        scores = np.concatenate(scores, axis=-1)
+            if aggregate and is_pair:
+                # collapse gene rows in native dtype, then upcast small result
+                if order is not None:
+                    score = score[order]
+                score = reduceat(score, group_starts, axis=0).astype("float32")
+                if mixed:
+                    full = np.zeros((n_snps, score.shape[1]), dtype="float32")
+                    full[group_snps] = score
+                    score = full
+            else:
+                score = score.astype("float32")
 
-        if abs_value:
-            scores = np.abs(scores)
+            key_scores.append(score)
 
-        # collapse pair-indexed (covgene/) rows to one per SNP
-        if gene_agg != "none" and "snp_idx" in stats_h5:
-            snp_idx = stats_h5["snp_idx"][:]
-            scores = aggregate_genes(scores, snp_idx, gene_agg)
-
-    return scores
+    return np.concatenate(key_scores, axis=-1)
 
 
-def aggregate_genes(scores: np.array, snp_idx: np.array, gene_agg: str):
-    """Collapse pair-indexed rows to one feature vector per SNP.
+def gene_groups(snp_idx: np.array):
+    """Contiguous SNP groupings for collapsing pair-indexed rows.
 
-    Args:
-      scores (:obj:`np.array`):
-        Pair-indexed feature matrix (num_pairs, T).
-      snp_idx (:obj:`np.array`):
-        Base SNP index for each row.
-      gene_agg (:obj:`str`):
-        "max" or "sum" reduction across each SNP's gene rows.
+    Returns `(order, group_starts, group_snps)`: rows taken in `order` (None
+    when `snp_idx` is already non-decreasing) fall into contiguous per-SNP
+    groups beginning at `group_starts`, with `group_snps` the SNP index of each
+    group. Groups are ordered by ascending SNP index, so the collapsed rows are
+    deterministic and consistent between the positive and negative files.
     """
-    reduce_fn = np.maximum.reduce if gene_agg == "max" else np.sum
-    snp_order = sorted(set(int(s) for s in snp_idx))
-    agg = [reduce_fn(scores[snp_idx == si], axis=0) for si in snp_order]
-    return np.array(agg, dtype="float32")
+    if np.all(np.diff(snp_idx) >= 0):
+        order, sorted_idx = None, snp_idx
+    else:
+        order = np.argsort(snp_idx, kind="stable")
+        sorted_idx = snp_idx[order]
+    group_starts = np.r_[0, np.flatnonzero(np.diff(sorted_idx)) + 1]
+    return order, group_starts, sorted_idx[group_starts]
 
 
 ################################################################################

--- a/src/westminster/scripts/westminster_eqtl_folds.py
+++ b/src/westminster/scripts/westminster_eqtl_folds.py
@@ -218,6 +218,20 @@ def main():
         help="Random forest min_samples_leaf",
     )
     gtex_group.add_argument(
+        "--classifier",
+        dest="classifier",
+        default="lgbm",
+        choices=["lgbm", "xgboost"],
+        help="Gradient-boosted tree classifier",
+    )
+    gtex_group.add_argument(
+        "--gene_agg",
+        dest="gene_agg",
+        default="max",
+        choices=["max", "sum"],
+        help="Aggregate covgene/ scores across genes (one feature per SNP)",
+    )
+    gtex_group.add_argument(
         "--metrics_only",
         default=False,
         action="store_true",
@@ -324,14 +338,14 @@ def main():
         ################################################################
         # fit classifiers
 
-        snp_stats_cov = [s for s in snp_stats if s.startswith("cov/")]
+        # classify SNP-indexed (cov/) and pair-indexed (covgene/) stats; gene/
+        # head stats are not produced by this wrapper
+        snp_stats_class = [
+            s for s in snp_stats if s.startswith("cov/") or s.startswith("covgene/")
+        ]
 
-        # SNPs (random forest)
-        # cmd_base = "westminster_classify.py -f 8 -i 20 -n 512 -s"
-        # SNPs (xgboost)
-        cmd_base = "westminster_classify.py -f 8 -i 20 -n 96 -s -x"
-        # indels
-        # cmd_base = 'westminster_classify.py -f 6 -i 64 -s'
+        clf_flag = "--lgbm" if args.classifier == "lgbm" else "-x"
+        cmd_base = f"westminster_classify.py -f 8 -i 20 -n 96 -s {clf_flag}"
         cmd_base += f" --msl {args.msl}"
 
         if args.class_targets_file is not None:
@@ -347,7 +361,7 @@ def main():
                     tissue = os.path.splitext(os.path.split(gtex_pos_vcf)[1])[0][:-4]
                     sad_pos = f"{it_out_dir}/{tissue}_pos/scores.h5"
                     sad_neg = f"{it_out_dir}/{tissue}_neg/scores.h5"
-                    for snp_stat in snp_stats_cov:
+                    for snp_stat in snp_stats_class:
                         stat_label = snp_stat.replace("/", "-")
                         class_out_dir = f"{it_out_dir}/{tissue}_class-{stat_label}"
                         if args.class_name is not None:
@@ -356,6 +370,8 @@ def main():
                             cmd_class = (
                                 f"{cmd_base} -o {class_out_dir} --stat {snp_stat}"
                             )
+                            if snp_stat.startswith("covgene/"):
+                                cmd_class += f" --gene_agg {args.gene_agg}"
                             cmd_class += f" {sad_pos} {sad_neg}"
                             if args.local:
                                 jobs.append(cmd_class)
@@ -377,13 +393,15 @@ def main():
             tissue = os.path.splitext(os.path.split(gtex_pos_vcf)[1])[0][:-4]
             sad_pos = f"{ens_out_dir}/{tissue}_pos/scores.h5"
             sad_neg = f"{ens_out_dir}/{tissue}_neg/scores.h5"
-            for snp_stat in snp_stats_cov:
+            for snp_stat in snp_stats_class:
                 stat_label = snp_stat.replace("/", "-")
                 class_out_dir = f"{ens_out_dir}/{tissue}_class-{stat_label}"
                 if args.class_name is not None:
                     class_out_dir += f"-{args.class_name}"
                 if not os.path.isfile(f"{class_out_dir}/stats.txt"):
                     cmd_class = f"{cmd_base} -o {class_out_dir} --stat {snp_stat}"
+                    if snp_stat.startswith("covgene/"):
+                        cmd_class += f" --gene_agg {args.gene_agg}"
                     cmd_class += f" {sad_pos} {sad_neg}"
                     if args.local:
                         jobs.append(cmd_class)

--- a/src/westminster/scripts/westminster_eqtl_folds.py
+++ b/src/westminster/scripts/westminster_eqtl_folds.py
@@ -497,6 +497,7 @@ def split_scores(it_out_dir: str, posneg: str, vcf_dir: str, snp_stats):
     """
     merge_dir = f"{it_out_dir}/merge_{posneg}"
     targets_cov_file = f"{merge_dir}/targets_cov.txt"
+    targets_covgene_file = f"{merge_dir}/targets_covgene.txt"
     targets_gene_file = f"{merge_dir}/targets_gene.txt"
     merge_h5_file = f"{merge_dir}/scores.h5"
 
@@ -561,6 +562,10 @@ def split_scores(it_out_dir: str, posneg: str, vcf_dir: str, snp_stats):
             tissue_dir = f"{it_out_dir}/{tissue_label}_{posneg}"
             os.makedirs(tissue_dir, exist_ok=True)
             shutil.copyfile(targets_cov_file, f"{tissue_dir}/targets_cov.txt")
+            if os.path.exists(targets_covgene_file):
+                shutil.copyfile(
+                    targets_covgene_file, f"{tissue_dir}/targets_covgene.txt"
+                )
             if os.path.exists(targets_gene_file):
                 shutil.copyfile(targets_gene_file, f"{tissue_dir}/targets_gene.txt")
 

--- a/src/westminster/scripts/westminster_eqtl_gtexg.py
+++ b/src/westminster/scripts/westminster_eqtl_gtexg.py
@@ -352,6 +352,10 @@ def _match_tissue_targets(
     if score_key.startswith("gene/"):
         targets_name = "targets_gene.txt"
         gene_targets = True
+    elif score_key.startswith("covgene/"):
+        # covgene/ stats span the gene-track subset, indexed by targets_covgene.txt
+        targets_name = "targets_covgene.txt"
+        gene_targets = False
     else:
         targets_name = "targets_cov.txt"
         gene_targets = False

--- a/src/westminster/scripts/westminster_gnomad_folds.py
+++ b/src/westminster/scripts/westminster_gnomad_folds.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 # =========================================================================
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+import itertools
 import os
 
 import slurm
@@ -26,6 +27,13 @@ westminster_gnomad_folds.py
 
 Benchmark Baskerville model replicates on Gnomad common vs rare variant classification.
 """
+
+
+def has_gene_stat(snp_stat: str) -> bool:
+    """True if a (possibly comma-joined) stat includes a pair-indexed key."""
+    return any(
+        k.startswith("covgene/") or k.startswith("gene/") for k in snp_stat.split(",")
+    )
 
 
 ################################################################################
@@ -136,6 +144,26 @@ def main():
     # classify options
     class_group = parser.add_argument_group("westminster_classify.py options")
     class_group.add_argument(
+        "--classifier",
+        dest="classifier",
+        default="lgbm",
+        choices=["lgbm", "xgboost"],
+        help="Gradient-boosted tree classifier",
+    )
+    class_group.add_argument(
+        "--gene_agg",
+        dest="gene_agg",
+        default="max",
+        choices=["max", "sum"],
+        help="Aggregate pair-indexed (covgene/, gene/) scores across genes per SNP",
+    )
+    class_group.add_argument(
+        "--metrics_only",
+        default=False,
+        action="store_true",
+        help="Skip SNP scoring; only fit classifiers on existing scores",
+    )
+    class_group.add_argument(
         "--cn",
         dest="class_name",
         default=None,
@@ -203,7 +231,7 @@ def main():
     fold_group.add_argument(
         "--gnomad",
         dest="gnomad_vcf_dir",
-        default="/group/fdna/public/genomes/hg38/gnomad",
+        default="/group/fdna/public/genomes/hg38/gnomad/vcf",
         help="Directory with GnomAD VCF files",
     )
     fold_group.add_argument(
@@ -268,30 +296,32 @@ def main():
         else:
             snp_stats.append(f"cov/{s}")
 
-    ################################################################
-    # score SNPs
+    if not args.metrics_only:
+        ################################################################
+        # score SNPs
 
-    # merge study/tissue variants
-    rare_vcf_file = f"{args.gnomad_vcf_dir}/rare{args.variants_label}.vcf"
-    common_vcf_file = f"{args.gnomad_vcf_dir}/common{args.variants_label}.vcf"
+        # merge study/tissue variants
+        rare_vcf_file = f"{args.gnomad_vcf_dir}/rare{args.variants_label}.vcf"
+        common_vcf_file = f"{args.gnomad_vcf_dir}/common{args.variants_label}.vcf"
 
-    # embed output in the models directory
-    args.embed = True
+        # embed output in the models directory
+        args.embed = True
 
-    # score rare SNPs
-    args.vcf_file = rare_vcf_file
-    args.out_dir = f"{gnomad_out_dir}/rare{args.variants_label}"
-    snp_folds(args)
+        # score rare SNPs
+        args.vcf_file = rare_vcf_file
+        args.out_dir = f"{gnomad_out_dir}/rare{args.variants_label}"
+        snp_folds(args)
 
-    # score common SNPs
-    args.vcf_file = common_vcf_file
-    args.out_dir = f"{gnomad_out_dir}/common{args.variants_label}"
-    snp_folds(args)
+        # score common SNPs
+        args.vcf_file = common_vcf_file
+        args.out_dir = f"{gnomad_out_dir}/common{args.variants_label}"
+        snp_folds(args)
 
     ################################################################
     # fit classifiers
 
-    cmd_base = "westminster_classify.py -f 10 -i 10 -x"
+    clf_flag = "--lgbm" if args.classifier == "lgbm" else "-x"
+    cmd_base = f"westminster_classify.py -f 10 -i 10 {clf_flag}"
     cmd_base += f" -l {args.learning_rate}"
     cmd_base += f" --md {args.max_depth}"
     cmd_base += f" -n {args.n_estimators}"
@@ -299,9 +329,9 @@ def main():
     if args.class_targets_file is not None:
         cmd_base += f" -t {args.class_targets_file}"
 
+    # classify each stat alone, plus every pair of stats combined
     classify_stats = list(snp_stats)
-    if len(classify_stats) > 1:
-        classify_stats.append(",".join(snp_stats))
+    classify_stats += [",".join(pair) for pair in itertools.combinations(snp_stats, 2)]
 
     jobs = []
     for ci in range(args.crosses):
@@ -325,6 +355,8 @@ def main():
 
                     cmd_class = f"{cmd_base} -o {class_out_dir}"
                     cmd_class += f" --stat {snp_stat}"
+                    if has_gene_stat(snp_stat):
+                        cmd_class += f" --gene_agg {args.gene_agg}"
                     cmd_class += f" {scores_rare_file} {scores_common_file}"
 
                     j = slurm.Job(
@@ -357,6 +389,8 @@ def main():
 
             cmd_class = f"{cmd_base} -o {class_out_dir}"
             cmd_class += f" --stat {snp_stat}"
+            if has_gene_stat(snp_stat):
+                cmd_class += f" --gene_agg {args.gene_agg}"
             cmd_class += f" {scores_rare_file} {scores_common_file}"
 
             j = slurm.Job(
@@ -367,7 +401,7 @@ def main():
                 f"{class_out_dir}.sb",
                 queue="standard",
                 cpu=16,
-                mem=6000,
+                mem=60000,
                 time="1-0:0:0",
             )
             jobs.append(j)

--- a/src/westminster/scripts/westminster_paqtl_folds.py
+++ b/src/westminster/scripts/westminster_paqtl_folds.py
@@ -479,6 +479,7 @@ def split_scores(it_out_dir: str, posneg: str, vcf_dir: str, snp_stats):
     """
     merge_dir = f"{it_out_dir}/merge_{posneg}"
     targets_cov_file = f"{merge_dir}/targets_cov.txt"
+    targets_covgene_file = f"{merge_dir}/targets_covgene.txt"
     targets_gene_file = f"{merge_dir}/targets_gene.txt"
     merge_h5_file = f"{merge_dir}/scores.h5"
 
@@ -544,6 +545,10 @@ def split_scores(it_out_dir: str, posneg: str, vcf_dir: str, snp_stats):
             tissue_dir = f"{it_out_dir}/{tissue_label}_{posneg}"
             os.makedirs(tissue_dir, exist_ok=True)
             shutil.copyfile(targets_cov_file, f"{tissue_dir}/targets_cov.txt")
+            if os.path.exists(targets_covgene_file):
+                shutil.copyfile(
+                    targets_covgene_file, f"{tissue_dir}/targets_covgene.txt"
+                )
             if os.path.exists(targets_gene_file):
                 shutil.copyfile(targets_gene_file, f"{tissue_dir}/targets_gene.txt")
 

--- a/src/westminster/scripts/westminster_paqtl_folds.py
+++ b/src/westminster/scripts/westminster_paqtl_folds.py
@@ -217,6 +217,20 @@ def main():
         help="Random forest min_samples_leaf",
     )
     gtex_group.add_argument(
+        "--classifier",
+        dest="classifier",
+        default="lgbm",
+        choices=["lgbm", "xgboost"],
+        help="Gradient-boosted tree classifier",
+    )
+    gtex_group.add_argument(
+        "--gene_agg",
+        dest="gene_agg",
+        default="max",
+        choices=["max", "sum"],
+        help="Aggregate covgene/ scores across genes (one feature per SNP)",
+    )
+    gtex_group.add_argument(
         "--metrics_only",
         default=False,
         action="store_true",
@@ -318,8 +332,9 @@ def main():
 
         snp_stats_gene = [s for s in snp_stats if s.startswith("covgene/")]
 
-        # paQTL classification (xgboost)
-        cmd_base = "westminster_classify.py -f 8 -i 20 -n 96 -s -x"
+        # paQTL classification on gene-aggregated covgene/ scores
+        clf_flag = "--lgbm" if args.classifier == "lgbm" else "-x"
+        cmd_base = f"westminster_classify.py -f 8 -i 20 -n 96 -s {clf_flag}"
         cmd_base += f" --msl {args.msl}"
 
         if args.class_targets_file is not None:
@@ -347,6 +362,7 @@ def main():
                             cmd_class = (
                                 f"{cmd_base} -o {class_out_dir} --stat {snp_stat}"
                             )
+                            cmd_class += f" --gene_agg {args.gene_agg}"
                             cmd_class += f" {sad_pos} {sad_neg}"
                             if args.local:
                                 jobs.append(cmd_class)
@@ -377,6 +393,7 @@ def main():
                     class_out_dir += f"-{args.class_name}"
                 if not os.path.isfile(f"{class_out_dir}/stats.txt"):
                     cmd_class = f"{cmd_base} -o {class_out_dir} --stat {snp_stat}"
+                    cmd_class += f" --gene_agg {args.gene_agg}"
                     cmd_class += f" {sad_pos} {sad_neg}"
                     if args.local:
                         jobs.append(cmd_class)

--- a/src/westminster/scripts/westminster_paqtl_gtex.py
+++ b/src/westminster/scripts/westminster_paqtl_gtex.py
@@ -198,6 +198,10 @@ def _match_tissue_targets(
     if score_key.startswith("gene/"):
         targets_name = "targets_gene.txt"
         gene_targets = True
+    elif score_key.startswith("covgene/"):
+        # covgene/ stats span the gene-track subset, indexed by targets_covgene.txt
+        targets_name = "targets_covgene.txt"
+        gene_targets = False
     else:
         targets_name = "targets_cov.txt"
         gene_targets = False

--- a/src/westminster/scripts/westminster_sqtl_folds.py
+++ b/src/westminster/scripts/westminster_sqtl_folds.py
@@ -217,6 +217,20 @@ def main():
         help="Random forest min_samples_leaf",
     )
     gtex_group.add_argument(
+        "--classifier",
+        dest="classifier",
+        default="lgbm",
+        choices=["lgbm", "xgboost"],
+        help="Gradient-boosted tree classifier",
+    )
+    gtex_group.add_argument(
+        "--gene_agg",
+        dest="gene_agg",
+        default="max",
+        choices=["max", "sum"],
+        help="Aggregate covgene/ scores across genes (one feature per SNP)",
+    )
+    gtex_group.add_argument(
         "--metrics_only",
         default=False,
         action="store_true",
@@ -318,8 +332,9 @@ def main():
 
         snp_stats_gene = [s for s in snp_stats if s.startswith("covgene/")]
 
-        # sQTL classification (xgboost)
-        cmd_base = "westminster_classify.py -f 8 -i 20 -n 96 -s -x"
+        # sQTL classification on gene-aggregated covgene/ scores
+        clf_flag = "--lgbm" if args.classifier == "lgbm" else "-x"
+        cmd_base = f"westminster_classify.py -f 8 -i 20 -n 96 -s {clf_flag}"
         cmd_base += f" --msl {args.msl}"
 
         if args.class_targets_file is not None:
@@ -347,6 +362,7 @@ def main():
                             cmd_class = (
                                 f"{cmd_base} -o {class_out_dir} --stat {snp_stat}"
                             )
+                            cmd_class += f" --gene_agg {args.gene_agg}"
                             cmd_class += f" {sad_pos} {sad_neg}"
                             if args.local:
                                 jobs.append(cmd_class)
@@ -377,6 +393,7 @@ def main():
                     class_out_dir += f"-{args.class_name}"
                 if not os.path.isfile(f"{class_out_dir}/stats.txt"):
                     cmd_class = f"{cmd_base} -o {class_out_dir} --stat {snp_stat}"
+                    cmd_class += f" --gene_agg {args.gene_agg}"
                     cmd_class += f" {sad_pos} {sad_neg}"
                     if args.local:
                         jobs.append(cmd_class)

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -6,6 +6,8 @@ import subprocess
 import h5py
 import numpy as np
 
+from westminster.scripts.westminster_classify import read_scores
+
 """
 westminster_classify.py
 """
@@ -41,6 +43,70 @@ def test_classify():
     # check auroc
     aurocs = np.load("%s/aurocs.npy" % out_dir)
     assert aurocs.mean() > 0.8
+
+
+def write_scores(h5_file, datasets):
+    """Write a tiny scores HDF5 with the given {key: array} datasets."""
+    with h5py.File(h5_file, "w") as h5:
+        for key, data in datasets.items():
+            dtype = "int64" if key == "snp_idx" else "float16"
+            h5.create_dataset(key, data=np.asarray(data), dtype=dtype)
+
+
+def test_read_scores_pair_max_and_sum():
+    # covgene/ pair rows collapse to one feature vector per SNP
+    # snp 0 -> rows 0,1 ; snp 1 -> row 2
+    covgene = np.array([[1.0, 8.0], [5.0, 2.0], [3.0, 4.0]])
+    snp_idx = np.array([0, 0, 1])
+    h5_file = "tests/data/covgene.h5"
+    write_scores(h5_file, {"covgene/logFC": covgene, "snp_idx": snp_idx})
+
+    scores_max = read_scores(h5_file, ["covgene/logFC"], None, gene_agg="max")
+    np.testing.assert_array_equal(scores_max, [[5.0, 8.0], [3.0, 4.0]])
+
+    scores_sum = read_scores(h5_file, ["covgene/logFC"], None, gene_agg="sum")
+    np.testing.assert_array_equal(scores_sum, [[6.0, 10.0], [3.0, 4.0]])
+
+
+def test_read_scores_pair_unsorted_snp_idx():
+    # collapsed rows are ordered by ascending SNP index regardless of row order
+    covgene = np.array([[3.0, 4.0], [1.0, 8.0], [5.0, 2.0]])
+    snp_idx = np.array([1, 0, 0])
+    h5_file = "tests/data/covgene_unsorted.h5"
+    write_scores(h5_file, {"covgene/logFC": covgene, "snp_idx": snp_idx})
+
+    scores = read_scores(h5_file, ["covgene/logFC"], None, gene_agg="max")
+    np.testing.assert_array_equal(scores, [[5.0, 8.0], [3.0, 4.0]])
+
+
+def test_read_scores_mixed_families_zero_fill():
+    # cov/ (3 SNPs) + covgene/ (genes only on SNPs 0 and 2): pair key reindexed
+    # onto the full SNP set, geneless SNP 1 zero-filled
+    cov = np.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]])
+    covgene = np.array([[10.0], [40.0], [70.0]])
+    snp_idx = np.array([0, 2, 2])
+    h5_file = "tests/data/mixed.h5"
+    write_scores(
+        h5_file, {"cov/logD2": cov, "covgene/logFC": covgene, "snp_idx": snp_idx}
+    )
+
+    scores = read_scores(h5_file, ["cov/logD2", "covgene/logFC"], None, gene_agg="max")
+    # cov columns unchanged; covgene column maxed per SNP, 0 where no gene rows
+    expected = np.array([[1.0, 1.0, 10.0], [2.0, 2.0, 0.0], [3.0, 3.0, 70.0]])
+    np.testing.assert_array_equal(scores, expected)
+
+
+def test_read_scores_abs_before_max():
+    # abs_value is applied before the max so the strongest-magnitude gene wins
+    covgene = np.array([[-9.0], [4.0]])
+    snp_idx = np.array([0, 0])
+    h5_file = "tests/data/covgene_abs.h5"
+    write_scores(h5_file, {"covgene/logFC": covgene, "snp_idx": snp_idx})
+
+    scores = read_scores(
+        h5_file, ["covgene/logFC"], None, abs_value=True, gene_agg="max"
+    )
+    np.testing.assert_array_equal(scores, [[9.0]])
 
 
 ################################################################################


### PR DESCRIPTION
This pull request adds support for aggregating gene-level features into per-SNP features in the Westminster classification pipeline, enabling more flexible and consistent handling of pair-indexed statistics (such as `covgene/` and `gene/` keys) across scripts. It introduces new command-line options for gene aggregation and classifier selection, updates the data reading logic to support aggregation, and improves the orchestration of classification jobs in several pipeline scripts.

**Key changes:**

**Gene aggregation and feature handling:**

* Added a `--gene_agg` option (with choices `"none"`, `"max"`, `"sum"`) to `westminster_classify.py`, `westminster_eqtl_folds.py`, `westminster_gnomad_folds.py`, and `westminster_paqtl_folds.py` to control aggregation of pair-indexed features (e.g., `covgene/` and `gene/`) into per-SNP features. The aggregation is performed at data read time, with support for combining different types of feature keys. (`[[1]](diffhunk://#diff-7e24c7ad51e1b41b168e5c657290ae74b7a5299688dc4bf537fad825bae1d28bR116-R124)`, `[[2]](diffhunk://#diff-5ad31b1268785225245c7a2159339eb94871004b3f476753e9c9ea6d6f20b3c6R220-R233)`, `[[3]](diffhunk://#diff-83171189ed0558a50b3feb8d5d4ae00755862108467374649648a3d9aede240fR219-R232)`, `[[4]](diffhunk://#diff-0d129facd89b8b8c3f79f888f3de7c8fdafb2f83fe66b8fa9123251d7373aef5R146-R165)`)
* Refactored the `read_scores` function in `westminster_classify.py` to support in-place absolute value application and gene aggregation, with detailed logic for handling mixed feature types and efficient memory usage. Added a helper `gene_groups` for contiguous SNP grouping. (`[src/westminster/scripts/westminster_classify.pyL810-R929](diffhunk://#diff-7e24c7ad51e1b41b168e5c657290ae74b7a5299688dc4bf537fad825bae1d28bL810-R929)`)

**Classifier and job orchestration improvements:**

* Added a `--classifier` option (with choices `"lgbm"`, `"xgboost"`) to select the tree classifier in classification scripts, and updated command construction logic to use the selected classifier. (`[[1]](diffhunk://#diff-5ad31b1268785225245c7a2159339eb94871004b3f476753e9c9ea6d6f20b3c6R220-R233)`, `[[2]](diffhunk://#diff-83171189ed0558a50b3feb8d5d4ae00755862108467374649648a3d9aede240fR219-R232)`, `[[3]](diffhunk://#diff-0d129facd89b8b8c3f79f888f3de7c8fdafb2f83fe66b8fa9123251d7373aef5R146-R165)`)
* Updated pipeline scripts to correctly pass `--gene_agg` when classifying pair-indexed stats, and to build classification jobs for all relevant stat combinations, including pairs. (`[[1]](diffhunk://#diff-5ad31b1268785225245c7a2159339eb94871004b3f476753e9c9ea6d6f20b3c6L327-R348)`, `[[2]](diffhunk://#diff-5ad31b1268785225245c7a2159339eb94871004b3f476753e9c9ea6d6f20b3c6L350-R364)`, `[[3]](diffhunk://#diff-5ad31b1268785225245c7a2159339eb94871004b3f476753e9c9ea6d6f20b3c6L380-R404)`, `[[4]](diffhunk://#diff-0d129facd89b8b8c3f79f888f3de7c8fdafb2f83fe66b8fa9123251d7373aef5L294-R334)`, `[[5]](diffhunk://#diff-0d129facd89b8b8c3f79f888f3de7c8fdafb2f83fe66b8fa9123251d7373aef5R358-R359)`, `[[6]](diffhunk://#diff-0d129facd89b8b8c3f79f888f3de7c8fdafb2f83fe66b8fa9123251d7373aef5R392-R393)`)

**Targets and file handling:**

* Improved logic for selecting the correct targets file for each stat type, including a new `targets_covgene.txt` for `covgene/` features, and ensured these files are copied to per-tissue directories as needed. (`[[1]](diffhunk://#diff-cc70b6dadf5d1118a6279c21fd4a6ce1d11db719c7f1a902f7b5eab4486af97bR355-R358)`, `[[2]](diffhunk://#diff-5ad31b1268785225245c7a2159339eb94871004b3f476753e9c9ea6d6f20b3c6R518)`, `[[3]](diffhunk://#diff-5ad31b1268785225245c7a2159339eb94871004b3f476753e9c9ea6d6f20b3c6R583-R586)`)

**Resource and configuration tweaks:**

* Increased memory allocation for classification jobs in `westminster_gnomad_folds.py` and fixed the default GnomAD VCF directory path. (`[[1]](diffhunk://#diff-0d129facd89b8b8c3f79f888f3de7c8fdafb2f83fe66b8fa9123251d7373aef5L206-R234)`, `[[2]](diffhunk://#diff-0d129facd89b8b8c3f79f888f3de7c8fdafb2f83fe66b8fa9123251d7373aef5L370-R404)`)
* Added a utility function `has_gene_stat` to identify pair-indexed stats in `westminster_gnomad_folds.py`. (`[src/westminster/scripts/westminster_gnomad_folds.pyR32-R38](diffhunk://#diff-0d129facd89b8b8c3f79f888f3de7c8fdafb2f83fe66b8fa9123251d7373aef5R32-R38)`)

These changes collectively enhance the flexibility, efficiency, and correctness of the classification workflows, especially when working with gene-level features and large-scale datasets.