### PR TITLE
Synchronize GTEx tissue discovery across eQTL/sQTL/paQTL evals

### DIFF
--- a/src/westminster/gtex.py
+++ b/src/westminster/gtex.py
@@ -4,7 +4,6 @@ import sys
 
 import h5py
 import numpy as np
-import pandas as pd
 import pybedtools
 
 txrev_keywords = {

--- a/src/westminster/gtex.py
+++ b/src/westminster/gtex.py
@@ -2,7 +2,9 @@ import glob
 import os
 import sys
 
+import h5py
 import numpy as np
+import pandas as pd
 import pybedtools
 
 txrev_keywords = {
@@ -125,6 +127,44 @@ def match_tissue_targets(targets_df, keyword, gene_targets=False, verbose=False)
                     print(ti, tid, tlab)
                 match_tis.append(ti)
     return np.array(match_tis)
+
+
+def covgene_targets_name(gtex_scores_file: str, score_key: str):
+    """Return the targets filename indexing a covgene/ stat's track axis.
+
+    Current scoring writes covgene/ datasets over the gene-track subset of the
+    strand-collapsed targets, indexed by targets_covgene.txt (baskerville
+    snps.py, `targets_out_df[gene_mask_strand]`). Runs predating that wrote
+    covgene/ at full strand-collapsed width, indexed by targets_cov.txt, and
+    have no targets_covgene.txt at all -- and `--metrics_only` reruns never
+    re-split, so the file cannot appear retroactively. Pick whichever table
+    matches the stored width so both layouts read correctly.
+
+    TODO(deprecate): once no covgene/ scores predating the targets_covgene.txt
+    split (westminster 5f643a7, 2026-05-31) are still in use, drop this probe
+    and go back to naming targets_covgene.txt unconditionally.
+
+    Args:
+        gtex_scores_file (str): Path to a tissue scores.h5.
+        score_key (str): Score key, e.g. covgene/logFC.
+
+    Returns:
+        str: Targets filename to read alongside scores.h5.
+    """
+    with h5py.File(gtex_scores_file, "r") as h5_file:
+        covgene_depth = h5_file[score_key].shape[-1]
+
+    for targets_name in ("targets_covgene.txt", "targets_cov.txt"):
+        targets_file = gtex_scores_file.replace("scores.h5", targets_name)
+        if os.path.isfile(targets_file):
+            targets_df = pd.read_csv(targets_file, sep="\t", index_col=0)
+            if len(targets_df) == covgene_depth:
+                return targets_name
+
+    raise ValueError(
+        f"No targets table matches {score_key} width {covgene_depth} in "
+        f"{os.path.dirname(gtex_scores_file)}"
+    )
 
 
 def discover_tissues(dir_glob, suffix, keyword_lookup):

--- a/src/westminster/gtex.py
+++ b/src/westminster/gtex.py
@@ -153,16 +153,21 @@ def covgene_targets_name(gtex_scores_file: str, score_key: str):
     with h5py.File(gtex_scores_file, "r") as h5_file:
         covgene_depth = h5_file[score_key].shape[-1]
 
+    scores_dir = os.path.dirname(gtex_scores_file)
     for targets_name in ("targets_covgene.txt", "targets_cov.txt"):
-        targets_file = gtex_scores_file.replace("scores.h5", targets_name)
+        targets_file = os.path.join(scores_dir, targets_name)
         if os.path.isfile(targets_file):
-            targets_df = pd.read_csv(targets_file, sep="\t", index_col=0)
-            if len(targets_df) == covgene_depth:
+            # count rows without a full parse; the caller re-reads the winner
+            with open(targets_file) as targets_open:
+                num_targets = sum(1 for _ in targets_open) - 1  # minus header
+            if num_targets == covgene_depth:
                 return targets_name
 
-    raise ValueError(
+    # not ValueError: callers catch that from add_scores to skip a tissue with
+    # unmatched targets, which would silently swallow a genuine layout error
+    raise RuntimeError(
         f"No targets table matches {score_key} width {covgene_depth} in "
-        f"{os.path.dirname(gtex_scores_file)}"
+        f"{scores_dir}"
     )
 
 
@@ -178,7 +183,7 @@ def discover_tissues(dir_glob, suffix, keyword_lookup):
         (tissue_label, keyword) pairs for labels found in keyword_lookup.
     """
     for path in sorted(glob.glob(dir_glob)):
-        tissue_label = os.path.basename(path)[: -len(suffix)]
+        tissue_label = os.path.basename(path).removesuffix(suffix)
         if tissue_label == "merge":
             continue
         keyword = keyword_lookup.get(tissue_label)

--- a/src/westminster/gtex.py
+++ b/src/westminster/gtex.py
@@ -1,34 +1,9 @@
+import glob
+import os
+import sys
+
 import numpy as np
 import pybedtools
-
-tissue_keywords = {
-    "Adipose_Subcutaneous": "adipose",
-    "Adipose_Visceral_Omentum": "adipose",
-    "Adrenal_Gland": "adrenal_gland",
-    "Artery_Aorta": "heart",
-    "Artery_Tibial": "heart",
-    "Brain_Cerebellum": "brain",
-    "Brain_Cortex": "brain",
-    "Breast_Mammary_Tissue": "breast",
-    "Colon_Sigmoid": "colon",
-    "Colon_Transverse": "colon",
-    "Esophagus_Mucosa": "esophagus",
-    "Esophagus_Muscularis": "esophagus",
-    "Liver": "liver",
-    "Lung": "lung",
-    "Muscle_Skeletal": "muscle",
-    "Nerve_Tibial": "nerve",
-    "Ovary": "ovary",
-    "Pancreas": "pancreas",
-    "Pituitary": "pituitary",
-    "Prostate": "prostate",
-    "Skin_Not_Sun_Exposed_Suprapubic": "skin",
-    "Spleen": "spleen",
-    "Stomach": "stomach",
-    "Testis": "testis",
-    "Thyroid": "thyroid",
-    "Whole_Blood": "blood",
-}
 
 txrev_keywords = {
     "GTEx_txrev_LCL": "lcl",
@@ -83,7 +58,7 @@ txrev_keywords = {
 }
 
 
-gtexv11_keywords = {
+gtex_keywords = {
     "Adipose_Subcutaneous": "adipose",
     "Adipose_Visceral_Omentum": "adipose",
     "Adrenal_Gland": "adrenal_gland",
@@ -150,6 +125,28 @@ def match_tissue_targets(targets_df, keyword, gene_targets=False, verbose=False)
                     print(ti, tid, tlab)
                 match_tis.append(ti)
     return np.array(match_tis)
+
+
+def discover_tissues(dir_glob, suffix, keyword_lookup):
+    """Discover tissues from files/dirs on disk and map them to keywords.
+
+    Args:
+        dir_glob: glob pattern matching one file/dir per tissue.
+        suffix: suffix to strip from each match's basename to get the tissue label.
+        keyword_lookup: dict mapping tissue label to matching keyword.
+
+    Yields:
+        (tissue_label, keyword) pairs for labels found in keyword_lookup.
+    """
+    for path in sorted(glob.glob(dir_glob)):
+        tissue_label = os.path.basename(path)[: -len(suffix)]
+        if tissue_label == "merge":
+            continue
+        keyword = keyword_lookup.get(tissue_label)
+        if keyword is None:
+            print(f"Skipping {tissue_label}: no keyword mapping.", file=sys.stderr)
+            continue
+        yield tissue_label, keyword
 
 
 def trim_dot(gene_id):

--- a/src/westminster/scripts/westminster_eqtl_gtex.py
+++ b/src/westminster/scripts/westminster_eqtl_gtex.py
@@ -12,8 +12,9 @@ from scipy.stats import spearmanr
 from sklearn.metrics import average_precision_score, roc_auc_score
 
 from westminster.gtex import (
+    discover_tissues,
+    gtex_keywords,
     match_tissue_targets,
-    tissue_keywords,
 )
 
 """
@@ -66,7 +67,10 @@ def main():
     os.makedirs(args.out_dir, exist_ok=True)
 
     metrics_rows = []
-    for tissue, keyword in tissue_keywords.items():
+    tissues = discover_tissues(
+        f"{args.gtex_vcf_dir}/*_pos.vcf", "_pos.vcf", gtex_keywords
+    )
+    for tissue, keyword in tissues:
         if args.verbose:
             print(tissue)
 

--- a/src/westminster/scripts/westminster_eqtl_gtexg.py
+++ b/src/westminster/scripts/westminster_eqtl_gtexg.py
@@ -11,6 +11,7 @@ from scipy.stats import spearmanr
 from sklearn.metrics import average_precision_score, roc_auc_score
 
 from westminster.gtex import (
+    covgene_targets_name,
     discover_tissues,
     gtex_keywords,
     match_tissue_targets,
@@ -358,7 +359,8 @@ def _match_tissue_targets(
         gene_targets = True
     elif score_key.startswith("covgene/"):
         # covgene/ stats span the gene-track subset, indexed by targets_covgene.txt
-        targets_name = "targets_covgene.txt"
+        # (older runs used the full strand-collapsed set; probe to tell them apart)
+        targets_name = covgene_targets_name(gtex_scores_file, score_key)
         gene_targets = False
     else:
         targets_name = "targets_cov.txt"

--- a/src/westminster/scripts/westminster_eqtl_gtexg.py
+++ b/src/westminster/scripts/westminster_eqtl_gtexg.py
@@ -11,9 +11,10 @@ from scipy.stats import spearmanr
 from sklearn.metrics import average_precision_score, roc_auc_score
 
 from westminster.gtex import (
+    discover_tissues,
+    gtex_keywords,
     match_tissue_targets,
     read_gene_tss,
-    tissue_keywords,
     trim_dot,
     variant_pos,
 )
@@ -82,7 +83,10 @@ def main():
     egene_metrics_rows = []
     egene_dist_rows = []
 
-    for tissue, keyword in tissue_keywords.items():
+    tissues = discover_tissues(
+        f"{args.gtex_vcf_dir}/*_pos.vcf", "_pos.vcf", gtex_keywords
+    )
+    for tissue, keyword in tissues:
         if args.verbose:
             print(tissue)
 

--- a/src/westminster/scripts/westminster_paqtl_gtex.py
+++ b/src/westminster/scripts/westminster_paqtl_gtex.py
@@ -9,6 +9,7 @@ import pandas as pd
 from sklearn.metrics import average_precision_score, roc_auc_score
 
 from westminster.gtex import (
+    covgene_targets_name,
     discover_tissues,
     match_tissue_targets,
     txrev_keywords,
@@ -193,7 +194,8 @@ def _match_tissue_targets(
         gene_targets = True
     elif score_key.startswith("covgene/"):
         # covgene/ stats span the gene-track subset, indexed by targets_covgene.txt
-        targets_name = "targets_covgene.txt"
+        # (older runs used the full strand-collapsed set; probe to tell them apart)
+        targets_name = covgene_targets_name(gtex_scores_file, score_key)
         gene_targets = False
     else:
         targets_name = "targets_cov.txt"

--- a/src/westminster/scripts/westminster_paqtl_gtex.py
+++ b/src/westminster/scripts/westminster_paqtl_gtex.py
@@ -3,16 +3,16 @@ import argparse
 import os
 import sys
 
-import glob
 import h5py
 import numpy as np
 import pandas as pd
 from sklearn.metrics import average_precision_score, roc_auc_score
 
 from westminster.gtex import (
+    discover_tissues,
     match_tissue_targets,
     txrev_keywords,
-    gtexv11_keywords,
+    gtex_keywords,
     trim_dot,
 )
 
@@ -65,23 +65,16 @@ def main():
     keyword_lookup = {
         t.replace("GTEx_txrev_", ""): kw for t, kw in txrev_keywords.items()
     }
-    keyword_lookup.update(gtexv11_keywords)
+    keyword_lookup.update(gtex_keywords)
 
     metrics_rows = []
 
-    for pos_dir in sorted(glob.glob(f"{args.paqtl_dir}/*_pos")):
-        tissue_label = os.path.basename(pos_dir).removesuffix("_pos")
-        if tissue_label == "merge":
-            continue  # AlphaGenome's merge_pos staging dir, not a tissue
-        if tissue_label not in keyword_lookup:
-            print(f"Skipping {tissue_label}: no keyword mapping.", file=sys.stderr)
-            continue
-        keyword = keyword_lookup[tissue_label]
-
+    tissues = discover_tissues(f"{args.paqtl_dir}/*_pos", "_pos", keyword_lookup)
+    for tissue_label, keyword in tissues:
         if args.verbose:
             print(tissue_label)
 
-        pos_scores_file = f"{pos_dir}/scores.h5"
+        pos_scores_file = f"{args.paqtl_dir}/{tissue_label}_pos/scores.h5"
         neg_scores_file = pos_scores_file.replace("_pos/", "_neg/")
         if not os.path.isfile(pos_scores_file) or not os.path.isfile(neg_scores_file):
             continue

--- a/src/westminster/scripts/westminster_sqtl_gtex.py
+++ b/src/westminster/scripts/westminster_sqtl_gtex.py
@@ -3,16 +3,16 @@ import argparse
 import os
 import sys
 
-import glob
 import h5py
 import numpy as np
 import pandas as pd
 from sklearn.metrics import average_precision_score, roc_auc_score
 
 from westminster.gtex import (
+    discover_tissues,
     match_tissue_targets,
     txrev_keywords,
-    gtexv11_keywords,
+    gtex_keywords,
     trim_dot,
 )
 
@@ -65,23 +65,16 @@ def main():
     keyword_lookup = {
         t.replace("GTEx_txrev_", ""): kw for t, kw in txrev_keywords.items()
     }
-    keyword_lookup.update(gtexv11_keywords)
+    keyword_lookup.update(gtex_keywords)
 
     metrics_rows = []
 
-    for pos_dir in sorted(glob.glob(f"{args.sqtl_dir}/*_pos")):
-        tissue_label = os.path.basename(pos_dir).removesuffix("_pos")
-        if tissue_label == "merge":
-            continue  # merge_pos/ staging dir, not a tissue
-        if tissue_label not in keyword_lookup:
-            print(f"Skipping {tissue_label}: no keyword mapping.", file=sys.stderr)
-            continue
-        keyword = keyword_lookup[tissue_label]
-
+    tissues = discover_tissues(f"{args.sqtl_dir}/*_pos", "_pos", keyword_lookup)
+    for tissue_label, keyword in tissues:
         if args.verbose:
             print(tissue_label)
 
-        pos_scores_file = f"{pos_dir}/scores.h5"
+        pos_scores_file = f"{args.sqtl_dir}/{tissue_label}_pos/scores.h5"
         neg_scores_file = pos_scores_file.replace("_pos/", "_neg/")
         if not os.path.isfile(pos_scores_file) or not os.path.isfile(neg_scores_file):
             continue


### PR DESCRIPTION
## Problem

The eQTL and sQTL/paQTL evals matched model outputs to GTEx tissues by two different mechanisms, so eQTL reported far fewer tissues than the others despite all three scoring the identical 50-tissue panel:

- `westminster_eqtl_gtex.py` / `_gtexg.py` iterated a hardcoded, GTEx-v8-era 26-tissue dict (`tissue_keywords`), a leftover from before the v11 upgrade.
- `westminster_sqtl_gtex.py` / `westminster_paqtl_gtex.py` discovered tissues from disk and matched them against the newer 49-tissue v11 keyword set.

The result: eQTL silently dropped 22 tissues the other two evals already covered — most brain subregions, plus `Artery_Coronary`, `Bladder`, `Heart_Atrial_Appendage`, `Heart_Left_Ventricle`, `Kidney_Cortex`, `Minor_Salivary_Gland`, `Skin_Sun_Exposed_Lower_leg`, `Small_Intestine_Terminal_Ileum`, `Uterus`, `Vagina`.

## Changes

**Tissue discovery (`eebc1c2`)**
- Add a shared `discover_tissues()` helper in `gtex.py` and route all four eval scripts through it, replacing the duplicated glob/lookup logic in the sQTL and paQTL scripts.
- Drop the dead `tissue_keywords` dict; it was a strict subset of the v11 set with identical keyword values.
- Rename `gtexv11_keywords` to `gtex_keywords` — there's no older set left to disambiguate from.

**covgene/ targets resolution (`d380a83`)**
- `covgene/` metrics resolved their track axis via `targets_covgene.txt` unconditionally, which only exists for scores split after 5f643a7. Older runs wrote `covgene/` at full strand-collapsed width with only `targets_cov.txt`, and `--metrics_only` reruns skip the split, so the file can never appear retroactively — those scores raised `FileNotFoundError`.
- Add `covgene_targets_name()`, which picks whichever targets table matches the stored `covgene/` width and raises if neither does, so both layouts read correctly instead of silently mis-indexing.

## Verification

Run against `models_ch1536_h8/ensemble/` in the `torch2.8` env:

- **eQTL** now reports 48 tissues (up from 26), skipping only `Cells_Cultured_fibroblasts` and `Cells_EBV-transformed_lymphocytes` — the two cell-line tissues with no matching model targets. This exactly matches the sQTL/paQTL tissue set.
- **sQTL** reproduces its prior 48-tissue output after the refactor, no regression.
- **covgene/** metrics reproduce archived values exactly on all 26 previously matched tissues for 2/10 `models_hydra` eqtl11 pre-split scores.

No CLI changes, so no `_folds.py` wrapper propagation is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)